### PR TITLE
feat: 선택 영역 글자단위 비교 (Quick Diff)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,8 +13,8 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@mantine/core": "^8.3.13",
-    "@mantine/hooks": "^8.3.13",
+    "@mantine/core": "^9.0.0",
+    "@mantine/hooks": "^9.0.0",
     "@tabler/icons-react": "^3.36.1",
     "clsx": "^2.1.1",
     "diffseek-core": "*",

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -97,9 +97,6 @@ body {
   opacity: 0.3;
 }
 
-.side-tag-button:hover {
-}
-
 .diff-list {
   padding: 2px 2px;
   list-style: none;
@@ -335,6 +332,217 @@ body {
     transform: translateY(0) scale(1);
     opacity: 1;
   }
+}
+
+/* ── Quick Diff Panel (sidebar) ── */
+
+.qdiff-panel {
+  border-top: 1px solid var(--mantine-color-gray-3, #dee2e6);
+  background: #fff;
+  overflow: hidden;
+  animation: qdiff-fade-in 120ms ease-out;
+}
+
+.qdiff-panel-content {
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: "돋움체", Consolas, monospace;
+  line-height: 1.6;
+  overflow-y: auto;
+  max-height: 200px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.qdiff-removed {
+  background-color: hsl(340 80% 88%);
+  color: hsl(340 60% 25%);
+}
+
+.qdiff-added {
+  background-color: hsl(160 60% 85%);
+  color: hsl(160 50% 20%);
+}
+
+.qdiff-unchanged {
+  color: #334155;
+}
+
+.qdiff-special {
+  color: #94a3b8;
+  font-size: 10px;
+}
+
+/* ── Quick Diff Menu Popover ── */
+
+.qdiff-menu {
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+  padding: 2px;
+  z-index: 10000;
+  animation: qdiff-fade-in 100ms ease-out;
+}
+
+.qdiff-menu-btn {
+  display: block;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-family: system-ui, sans-serif;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  color: #334155;
+  white-space: nowrap;
+}
+
+.qdiff-menu-btn:hover {
+  background: #e2e8f0;
+}
+
+/* ── Quick Diff Result Popover ── */
+
+.qdiff-result {
+  resize: both;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+  z-index: 9999;
+  animation: qdiff-fade-in 120ms ease-out;
+  display: flex;
+  flex-direction: column;
+}
+
+.qdiff-result-title {
+  font-size: 11px;
+  color: #64748b;
+  flex: 1;
+  margin-left: 4px;
+}
+
+.qdiff-result-titlebar {
+  display: flex;
+  align-items: center;
+  padding: 2px 4px;
+  cursor: grab;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 252, 0.8);
+  border-radius: 8px 8px 0 0;
+  user-select: none;
+}
+
+.qdiff-result-titlebar:active {
+  cursor: grabbing;
+}
+
+.qdiff-result-close {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #94a3b8;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  padding: 0;
+}
+
+.qdiff-result-close:hover {
+  background: rgba(148, 163, 184, 0.2);
+  color: #ef4444;
+}
+
+.qdiff-result-content {
+  padding: 16px 20px;
+  /* font-size: JS에서 동적 설정 */
+  font-family: "바탕체", serif;
+  line-height: 1.6;
+  overflow: auto;
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ── Quick Diff View Mode Buttons ── */
+
+.qdiff-viewmode-btns {
+  display: flex;
+  gap: 1px;
+  margin-right: 4px;
+}
+
+.qdiff-viewmode-btn {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  border-radius: 3px;
+  padding: 0;
+  cursor: pointer;
+  color: #94a3b8;
+}
+
+.qdiff-viewmode-btn:hover {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.qdiff-viewmode-btn.active {
+  color: #334155;
+  background: rgba(148, 163, 184, 0.25);
+}
+
+/* ── Quick Diff Split Layout ── */
+
+.qdiff-split-h {
+  display: flex;
+  gap: 0;
+  height: 100%;
+}
+
+.qdiff-split-h > .qdiff-split-left,
+.qdiff-split-h > .qdiff-split-right {
+  flex: 1;
+  overflow: auto;
+  min-width: 0;
+  font-size: 14px;
+}
+
+.qdiff-split-h > .qdiff-split-left {
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.qdiff-split-v {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  height: 100%;
+}
+
+.qdiff-split-v > .qdiff-split-left,
+.qdiff-split-v > .qdiff-split-right {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  font-size: 14px;
+}
+
+.qdiff-split-v > .qdiff-split-left {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+@keyframes qdiff-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .app-header progress {

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { DiffseekProvider } from './bridge/diffseek-provider';
 import { AppHeader } from './components/app-header';
 import { DiffList } from './components/diff-list';
+import { InlineDiffPopover } from './components/inline-diff-popover';
 import { OutlineModal } from './components/outline-modal';
 import { BusyIndicator } from "./components/busy-indicator";
 import { diffWorkflowStatusAtom, extensionEnabledAtom } from './states/core-atoms';
@@ -114,6 +115,7 @@ export function App() {
                     <DiffList />
                     <AppHeader />
                 </aside>
+                <InlineDiffPopover engine={engine} />
                 <OutlineModal opened={outlineOpened} onClose={() => setOutlineOpened(false)} />
                 {/* <BusyIndicator busy={diffWorkflowStatus.phase !== "idle"} /> */}
             </Provider>

--- a/app/src/components/inline-diff-popover.tsx
+++ b/app/src/components/inline-diff-popover.tsx
@@ -1,0 +1,359 @@
+import type { DiffseekEngine } from "@core";
+import { FloatingWindow } from "@mantine/core";
+import { useQuickDiff } from "@/hooks/use-quick-diff";
+import { QuickDiffType, type QuickDiffEntry } from "@/quick-diff";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const RESULT_MIN_WIDTH = 160;
+const RESULT_MIN_HEIGHT = 60;
+const RESULT_MAX_WIDTH = 420;
+const RESULT_MAX_HEIGHT = 320;
+const RESULT_FONT_MIN = 12;
+const RESULT_FONT_MAX = 72;
+const MARGIN = 8;
+const MENU_GAP = 20;
+
+// ── 뷰 모드 ──
+
+type ViewMode = "inline" | "side-by-side" | "stacked";
+
+// ── 공통 렌더 유틸 ──
+
+function renderSpecialChars(text: string): (string | React.ReactNode)[] {
+    const parts: (string | React.ReactNode)[] = [];
+    let buf = "";
+    let key = 0;
+    for (const ch of text) {
+        if (ch === "\n") {
+            if (buf) { parts.push(buf); buf = ""; }
+            parts.push(<span key={key++} className="qdiff-special">{"↵"}</span>);
+            parts.push(<br key={key++} />);
+        } else if (ch === "\t") {
+            if (buf) { parts.push(buf); buf = ""; }
+            parts.push(<span key={key++} className="qdiff-special">{"→"}</span>);
+        } else {
+            buf += ch;
+        }
+    }
+    if (buf) parts.push(buf);
+    return parts;
+}
+
+function renderInline(entries: QuickDiffEntry[]) {
+    return entries.map((entry, i) => {
+        const className =
+            entry.type === QuickDiffType.Removed ? "qdiff-removed" :
+            entry.type === QuickDiffType.Added ? "qdiff-added" :
+            "qdiff-unchanged";
+        return (
+            <span key={i} className={className}>
+                {renderSpecialChars(entry.text)}
+            </span>
+        );
+    });
+}
+
+function renderSplit(entries: QuickDiffEntry[], layout: "side-by-side" | "stacked") {
+    const leftParts: React.ReactNode[] = [];
+    const rightParts: React.ReactNode[] = [];
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const rendered = <span key={i}>{renderSpecialChars(entry.text)}</span>;
+        if (entry.type === QuickDiffType.Unchanged) {
+            leftParts.push(rendered);
+            rightParts.push(rendered);
+        } else if (entry.type === QuickDiffType.Removed) {
+            leftParts.push(<span key={i} className="qdiff-removed">{renderSpecialChars(entry.text)}</span>);
+        } else {
+            rightParts.push(<span key={i} className="qdiff-added">{renderSpecialChars(entry.text)}</span>);
+        }
+    }
+    const cls = layout === "side-by-side" ? "qdiff-split-h" : "qdiff-split-v";
+    return (
+        <div className={cls}>
+            <div className="qdiff-split-left">{leftParts}</div>
+            <div className="qdiff-split-right">{rightParts}</div>
+        </div>
+    );
+}
+
+function renderContent(entries: QuickDiffEntry[], viewMode: ViewMode) {
+    if (viewMode === "inline") return renderInline(entries);
+    return renderSplit(entries, viewMode);
+}
+
+// ── SelectionMenu ──
+
+function SelectionMenu({ x, y, opacity, workspace, onClickDiff }: { x: number; y: number; opacity: number; workspace: HTMLElement; onClickDiff: () => void }) {
+    const ref = useRef<HTMLDivElement>(null);
+    const [pos, setPos] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
+
+    useEffect(() => {
+        if (!ref.current) return;
+        const w = ref.current.offsetWidth;
+        const h = ref.current.offsetHeight;
+        const vh = window.innerHeight;
+
+        const wsRect = workspace.getBoundingClientRect();
+        const left = Math.max(wsRect.left + MARGIN, Math.min(x, wsRect.right - w - MARGIN));
+        const above = y - MENU_GAP - h >= 0;
+
+        setPos(above
+            ? { left, bottom: vh - y + MENU_GAP }
+            : { left, top: y + MENU_GAP }
+        );
+    }, [x, y, workspace]);
+
+    return (
+        <div
+            ref={ref}
+            className="qdiff-menu"
+            style={{
+                position: "fixed",
+                left: pos?.left ?? x,
+                top: pos?.top,
+                bottom: pos?.bottom,
+                opacity,
+                visibility: pos ? "visible" : "hidden",
+            }}
+            onMouseDown={(e) => e.preventDefault()}
+        >
+            <button className="qdiff-menu-btn" onClick={onClickDiff}>
+                Diff
+            </button>
+        </div>
+    );
+}
+
+// ── ResultPopover (FloatingWindow) ──
+
+function ResultPopover({ result, anchorX, anchorY, workspace, onDismiss }: {
+    result: { entries: QuickDiffEntry[] };
+    anchorX: number;
+    anchorY: number;
+    workspace: HTMLElement;
+    onDismiss: (popoverEl?: HTMLElement | null) => void;
+}) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const resizeObserverRef = useRef<ResizeObserver | null>(null);
+    const [viewMode, setViewMode] = useState<ViewMode>("inline");
+    const contentCallbackRef = useCallback((node: HTMLDivElement | null) => {
+        if (resizeObserverRef.current) {
+            resizeObserverRef.current.disconnect();
+            resizeObserverRef.current = null;
+        }
+        contentRef.current = node;
+        if (!node) return;
+
+        if (viewMode === "inline") {
+            fitFont(node);
+
+            const container = node.parentElement;
+            if (container) {
+                let rafId: number | null = null;
+                const observer = new ResizeObserver(() => {
+                    if (rafId !== null) return;
+                    rafId = requestAnimationFrame(() => {
+                        rafId = null;
+                        if (contentRef.current) fitFont(contentRef.current);
+                    });
+                });
+                observer.observe(container);
+                resizeObserverRef.current = observer;
+            }
+        } else {
+            node.style.fontSize = "";
+        }
+    }, [result, viewMode]);
+    const setPositionRef = useRef<((pos: { top?: number; left?: number; right?: number; bottom?: number }) => void) | null>(null);
+    const [ready, setReady] = useState(false);
+    const [wsSize, setWsSize] = useState({ width: workspace.offsetWidth, height: workspace.offsetHeight });
+
+    // workspace 리사이즈 추적 + 팝업 위치 viewport clamp + cleanup
+    useEffect(() => {
+        const handleResize = () => {
+            setWsSize({ width: workspace.offsetWidth, height: workspace.offsetHeight });
+
+            // 팝업이 viewport 밖으로 밀려났으면 보정
+            const root = rootRef.current;
+            const setPos = setPositionRef.current;
+            if (root && setPos) {
+                const rect = root.getBoundingClientRect();
+                const vw = window.innerWidth;
+                const vh = window.innerHeight;
+                let left = rect.left;
+                let top = rect.top;
+                let needsUpdate = false;
+
+                if (rect.right > vw) { left = vw - rect.width; needsUpdate = true; }
+                if (rect.bottom > vh) { top = vh - rect.height; needsUpdate = true; }
+                if (left < 0) { left = 0; needsUpdate = true; }
+                if (top < 0) { top = 0; needsUpdate = true; }
+
+                if (needsUpdate) setPos({ left, top });
+            }
+        };
+
+        const wsObserver = new ResizeObserver(handleResize);
+        wsObserver.observe(workspace);
+        window.addEventListener("resize", handleResize);
+        return () => {
+            wsObserver.disconnect();
+            window.removeEventListener("resize", handleResize);
+            resizeObserverRef.current?.disconnect();
+        };
+    }, []);
+
+    // 초기 위치 계산: 워크스페이스 기준
+    const initialPosition = useMemo(() => {
+        const wsRect = workspace.getBoundingClientRect();
+        // 대략적인 초기 위치 (정확한 크기는 모르지만 max 기준으로 추정)
+        const left = Math.max(wsRect.left + MARGIN, Math.min(anchorX, wsRect.right - RESULT_MAX_WIDTH - MARGIN));
+        const top = anchorY + MENU_GAP;
+        return { top, left };
+    }, [anchorX, anchorY, workspace]);
+
+    // 마운트 후 실제 크기로 위치 보정
+    useEffect(() => {
+        if (!rootRef.current || !setPositionRef.current) return;
+        const w = rootRef.current.offsetWidth;
+        const h = rootRef.current.offsetHeight;
+        const wsRect = workspace.getBoundingClientRect();
+
+        const left = Math.max(wsRect.left + MARGIN, Math.min(anchorX, wsRect.right - w - MARGIN));
+        let top: number;
+        if (anchorY + MENU_GAP + h <= wsRect.bottom) {
+            top = anchorY + MENU_GAP;
+        } else if (anchorY - MENU_GAP - h >= wsRect.top) {
+            top = anchorY - MENU_GAP - h;
+        } else {
+            top = Math.max(wsRect.top + MARGIN, wsRect.bottom - h - MARGIN);
+        }
+
+        setPositionRef.current({ top, left });
+        setReady(true);
+    }, [anchorX, anchorY, workspace]);
+
+    // 스크롤바가 안 생기는 최대 폰트 크기 탐색 (동기 reflow, binary search)
+    function fitFont(el: HTMLElement) {
+        let lo = RESULT_FONT_MIN, hi = RESULT_FONT_MAX;
+
+        // max에서 안 넘치면 그대로
+        el.style.fontSize = hi + "px";
+        if (el.scrollHeight <= el.clientHeight && el.scrollWidth <= el.clientWidth) return;
+
+        // binary search (최대 8회)
+        let bestSize = lo;
+        for (let i = 0; i < 8 && hi - lo > 0.5; i++) {
+            const mid = (lo + hi) / 2;
+            el.style.fontSize = mid + "px";
+            if (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth) {
+                hi = mid;
+            } else {
+                bestSize = mid;
+                lo = mid;
+            }
+        }
+        // 서브픽셀 반올림으로 미세하게 넘칠 수 있으므로 0.5px 여유
+        el.style.fontSize = (bestSize > RESULT_FONT_MIN ? bestSize - 0.5 : bestSize) + "px";
+    }
+
+    // ESC로 닫기
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onDismiss(rootRef.current);
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onDismiss]);
+
+    const handleClose = useCallback(() => {
+        onDismiss(rootRef.current);
+    }, [onDismiss]);
+
+    return (
+        <FloatingWindow
+            ref={rootRef}
+            setPositionRef={setPositionRef}
+            className="qdiff-result"
+            enabled
+            constrainToViewport
+            constrainOffset={MARGIN}
+            dragHandleSelector=".qdiff-result-grip"
+            excludeDragHandleSelector=".qdiff-result-close, .qdiff-viewmode-btn"
+            initialPosition={initialPosition}
+            zIndex={9999}
+            onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+            style={{
+                width: RESULT_MAX_WIDTH,
+                height: RESULT_MAX_HEIGHT,
+                minWidth: RESULT_MIN_WIDTH,
+                minHeight: RESULT_MIN_HEIGHT,
+                maxWidth: wsSize.width,
+                maxHeight: wsSize.height,
+            }}
+        >
+            <div className="qdiff-result-titlebar qdiff-result-grip">
+                <span className="qdiff-result-title">선택 영역 비교</span>
+                <div className="qdiff-viewmode-btns">
+                    <button className={`qdiff-viewmode-btn${viewMode === "stacked" ? " active" : ""}`} onClick={() => setViewMode("stacked")} title="위아래">
+                        <svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="10" height="4" rx="1" fill="currentColor" /><rect x="1" y="7" width="10" height="4" rx="1" fill="currentColor" /></svg>
+                    </button>
+                    <button className={`qdiff-viewmode-btn${viewMode === "side-by-side" ? " active" : ""}`} onClick={() => setViewMode("side-by-side")} title="좌우">
+                        <svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="4" height="10" rx="1" fill="currentColor" /><rect x="7" y="1" width="4" height="10" rx="1" fill="currentColor" /></svg>
+                    </button>
+                    <button className={`qdiff-viewmode-btn${viewMode === "inline" ? " active" : ""}`} onClick={() => setViewMode("inline")} title="인라인">
+                        <svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="10" height="10" rx="1" fill="currentColor" /></svg>
+                    </button>
+                </div>
+                <button className="qdiff-result-close" onClick={handleClose}>
+                    <svg width="10" height="10" viewBox="0 0 10 10">
+                        <path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                </button>
+            </div>
+            <div ref={contentCallbackRef} className="qdiff-result-content">
+                {renderContent(result.entries, viewMode)}
+            </div>
+        </FloatingWindow>
+    );
+}
+
+// ── Root ──
+
+export function InlineDiffPopover({ engine }: { engine: DiffseekEngine }) {
+    const { available, menu, menuOpacity, result, resultPosition, requestDiff, dismissResult } = useQuickDiff(engine);
+
+    // Alt+Q 단축키
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.altKey && e.code === "KeyQ") {
+                e.preventDefault();
+                if (available) requestDiff();
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [available, requestDiff]);
+
+    return (
+        <>
+            {menu && (
+                <SelectionMenu x={menu.x} y={menu.y} opacity={menuOpacity} workspace={engine.workspaceEl} onClickDiff={requestDiff} />
+            )}
+            {result && resultPosition && (
+                <ResultPopover
+                    result={result}
+                    anchorX={resultPosition.x}
+                    anchorY={resultPosition.y}
+                    workspace={engine.workspaceEl}
+                    onDismiss={dismissResult}
+                />
+            )}
+        </>
+    );
+}

--- a/app/src/hooks/use-quick-diff.ts
+++ b/app/src/hooks/use-quick-diff.ts
@@ -1,0 +1,218 @@
+import type { DiffseekEngine } from "@core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { computeCharDiff, type QuickDiffEntry, type QuickDiffResult } from "@/quick-diff";
+
+const CHAR_THRESHOLD = 10000;
+const MENU_FADE_START = 40;
+const MENU_FADE_END = 120;
+
+type Span = { start: number; end: number };
+
+type SelectionMenuState = {
+    x: number;
+    y: number;
+    anchorX: number;
+    anchorY: number;
+    leftSpan: Span;
+    rightSpan: Span;
+};
+
+export type QuickDiffState = {
+    available: boolean;
+    menu: SelectionMenuState | null;
+    menuOpacity: number;
+    result: QuickDiffResult | null;
+    resultPosition: { x: number; y: number } | null;
+    requestDiff: () => void;
+    dismissResult: (popoverEl?: HTMLElement | null) => void;
+};
+
+export function useQuickDiff(engine: DiffseekEngine): QuickDiffState {
+    const [available, setAvailable] = useState(false);
+    const [menu, setMenu] = useState<SelectionMenuState | null>(null);
+    const [menuOpacity, setMenuOpacity] = useState(1);
+    const [result, setResult] = useState<QuickDiffResult | null>(null);
+    const [resultPosition, setResultPosition] = useState<{ x: number; y: number } | null>(null);
+    const savedSelectionRef = useRef<Range | null>(null);
+    const lastSpanRef = useRef<{ left: Span; right: Span } | null>(null);
+
+    const menuRef = useRef(menu);
+    menuRef.current = menu;
+    const resultPositionRef = useRef(resultPosition);
+    resultPositionRef.current = resultPosition;
+    const hasResultRef = useRef(false);
+    hasResultRef.current = result !== null;
+
+    useEffect(() => {
+        const updateLastSpan = (span: { left: Span; right: Span } | null) => {
+            lastSpanRef.current = span;
+            setAvailable(span !== null);
+        };
+        let isDragging = false;
+
+        const workspace = engine.workspaceEl;
+
+        const handleMouseDown = (e: MouseEvent) => {
+            if (!workspace.contains(e.target as Node)) return;
+            isDragging = true;
+            closeMenu();
+        };
+
+        const handleMouseUp = (e: MouseEvent) => {
+            if (!isDragging) return;
+            isDragging = false;
+
+            if (lastSpanRef.current) {
+                const sel = window.getSelection();
+                if (sel && sel.rangeCount > 0 && !sel.getRangeAt(0).collapsed) {
+                    setMenu({
+                        x: e.clientX,
+                        y: e.clientY,
+                        anchorX: e.clientX,
+                        anchorY: e.clientY,
+                        leftSpan: lastSpanRef.current.left,
+                        rightSpan: lastSpanRef.current.right,
+                    });
+                }
+            }
+        };
+
+        const closeMenu = () => {
+            setMenu(null);
+            setMenuOpacity(1);
+        };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            if (menuRef.current) {
+                const dx = e.clientX - menuRef.current.anchorX;
+                const dy = e.clientY - menuRef.current.anchorY;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+
+                if (dist >= MENU_FADE_END) {
+                    closeMenu();
+                } else if (dist > MENU_FADE_START) {
+                    setMenuOpacity(1 - (dist - MENU_FADE_START) / (MENU_FADE_END - MENU_FADE_START));
+                } else {
+                    setMenuOpacity(1);
+                }
+            }
+        };
+
+        const handleScroll = () => {
+            if (menuRef.current) {
+                closeMenu();
+            }
+        };
+
+        const handleSelectionChange = (data: { left: Span | null; right: Span | null }) => {
+            if (data.left && data.right) {
+                updateLastSpan({ left: data.left, right: data.right });
+            } else {
+                updateLastSpan(null);
+                closeMenu();
+            }
+        };
+
+        document.addEventListener("mousedown", handleMouseDown);
+        document.addEventListener("mouseup", handleMouseUp);
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("scroll", handleScroll, true);
+        const unsub = engine.on("selectionChanged", handleSelectionChange);
+
+        return () => {
+            document.removeEventListener("mousedown", handleMouseDown);
+            document.removeEventListener("mouseup", handleMouseUp);
+            document.removeEventListener("mousemove", handleMouseMove);
+            document.removeEventListener("scroll", handleScroll, true);
+            unsub();
+        };
+    }, [engine]);
+
+    const requestDiff = useCallback(() => {
+        const span = lastSpanRef.current;
+        if (!span) return;
+
+        const sel = window.getSelection();
+        if (sel && sel.rangeCount > 0) {
+            savedSelectionRef.current = sel.getRangeAt(0).cloneRange();
+        } else {
+            savedSelectionRef.current = null;
+        }
+
+        const alreadyOpen = hasResultRef.current && resultPositionRef.current !== null;
+        const m = menuRef.current;
+        const posX = alreadyOpen ? resultPositionRef.current!.x : (m?.x ?? window.innerWidth / 2);
+        const posY = alreadyOpen ? resultPositionRef.current!.y : (m?.y ?? window.innerHeight / 2);
+        setMenu(null);
+
+        const segments = engine.segmentSpanPair(span.left, span.right);
+        if (segments.length === 0) {
+            setResult(null);
+            setResultPosition(null);
+            return;
+        }
+
+        const allEntries: QuickDiffEntry[] = [];
+        let totalChars = 0;
+
+        for (let si = 0; si < segments.length; si++) {
+            const seg = segments[si];
+            let leftText = seg.left ? (engine.getTextForTokenSpan("left", seg.left) ?? "") : "";
+            let rightText = seg.right ? (engine.getTextForTokenSpan("right", seg.right) ?? "") : "";
+
+            if (si === segments.length - 1) {
+                leftText = leftText.trimEnd();
+                rightText = rightText.trimEnd();
+            }
+
+            totalChars += leftText.length + rightText.length;
+            if (totalChars > CHAR_THRESHOLD * 2) {
+                setResult(null);
+                setResultPosition(null);
+                return;
+            }
+
+            const segResult = computeCharDiff(leftText, rightText);
+
+            for (const entry of segResult.entries) {
+                const last = allEntries[allEntries.length - 1];
+                if (last && last.type === entry.type) {
+                    last.text += entry.text;
+                } else {
+                    allEntries.push({ ...entry });
+                }
+            }
+        }
+
+        setResult({
+            leftText: "",
+            rightText: "",
+            entries: allEntries,
+        });
+        setResultPosition({ x: posX, y: posY });
+    }, [engine]);
+
+    const dismissResult = useCallback((popoverEl?: HTMLElement | null) => {
+        const saved = savedSelectionRef.current;
+        if (popoverEl && saved) {
+            const sel = window.getSelection();
+            const currentRange = sel && sel.rangeCount > 0 ? sel.getRangeAt(0) : null;
+            const selectionInsidePopover = currentRange
+                && popoverEl.contains(currentRange.startContainer)
+                && popoverEl.contains(currentRange.endContainer);
+
+            if (selectionInsidePopover
+                && saved.startContainer.isConnected
+                && saved.endContainer.isConnected) {
+                sel!.removeAllRanges();
+                sel!.addRange(saved);
+            }
+        }
+        savedSelectionRef.current = null;
+
+        setResult(null);
+        setResultPosition(null);
+    }, []);
+
+    return { available, menu, menuOpacity, result, resultPosition, requestDiff, dismissResult };
+}

--- a/app/src/quick-diff/compute-char-diff.ts
+++ b/app/src/quick-diff/compute-char-diff.ts
@@ -1,0 +1,78 @@
+import { QuickDiffType, type QuickDiffEntry, type QuickDiffResult } from "./types";
+
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function toGraphemes(text: string): string[] {
+    const result: string[] = [];
+    for (const { segment } of segmenter.segment(text)) {
+        result.push(segment);
+    }
+    return result;
+}
+
+/**
+ * LCS 기반 글자(grapheme) 단위 diff.
+ * O(n*m) DP.
+ */
+export function computeCharDiff(leftText: string, rightText: string): QuickDiffResult {
+    const leftG = toGraphemes(leftText);
+    const rightG = toGraphemes(rightText);
+    const n = leftG.length;
+    const m = rightG.length;
+
+    if (n === 0 && m === 0) {
+        return { leftText, rightText, entries: [] };
+    }
+    if (n === 0) {
+        return { leftText, rightText, entries: [{ type: QuickDiffType.Added, text: rightText }] };
+    }
+    if (m === 0) {
+        return { leftText, rightText, entries: [{ type: QuickDiffType.Removed, text: leftText }] };
+    }
+
+    const cols = m + 1;
+    const dp = new Int32Array((n + 1) * cols);
+
+    for (let i = 1; i <= n; i++) {
+        const row = i * cols;
+        const prevRow = (i - 1) * cols;
+        for (let j = 1; j <= m; j++) {
+            if (leftG[i - 1] === rightG[j - 1]) {
+                dp[row + j] = dp[prevRow + j - 1] + 1;
+            } else {
+                dp[row + j] = dp[prevRow + j] > dp[row + j - 1]
+                    ? dp[prevRow + j]
+                    : dp[row + j - 1];
+            }
+        }
+    }
+
+    const rawOps: { type: QuickDiffType; grapheme: string }[] = [];
+    let i = n, j = m;
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && leftG[i - 1] === rightG[j - 1]) {
+            rawOps.push({ type: QuickDiffType.Unchanged, grapheme: leftG[i - 1] });
+            i--; j--;
+        } else if (j > 0 && (i === 0 || dp[(i - 1) * cols + j] <= dp[i * cols + j - 1])) {
+            rawOps.push({ type: QuickDiffType.Added, grapheme: rightG[j - 1] });
+            j--;
+        } else {
+            rawOps.push({ type: QuickDiffType.Removed, grapheme: leftG[i - 1] });
+            i--;
+        }
+    }
+
+    rawOps.reverse();
+
+    const entries: QuickDiffEntry[] = [];
+    for (const op of rawOps) {
+        const last = entries[entries.length - 1];
+        if (last && last.type === op.type) {
+            last.text += op.grapheme;
+        } else {
+            entries.push({ type: op.type, text: op.grapheme });
+        }
+    }
+
+    return { leftText, rightText, entries };
+}

--- a/app/src/quick-diff/index.ts
+++ b/app/src/quick-diff/index.ts
@@ -1,0 +1,2 @@
+export { computeCharDiff } from "./compute-char-diff";
+export { QuickDiffType, type QuickDiffEntry, type QuickDiffResult } from "./types";

--- a/app/src/quick-diff/types.ts
+++ b/app/src/quick-diff/types.ts
@@ -1,0 +1,16 @@
+export const enum QuickDiffType {
+    Unchanged = 0,
+    Removed = 1,
+    Added = 2,
+}
+
+export type QuickDiffEntry = {
+    type: QuickDiffType;
+    text: string;
+};
+
+export type QuickDiffResult = {
+    leftText: string;
+    rightText: string;
+    entries: QuickDiffEntry[];
+};

--- a/core/src/engine/diffseek-engine.ts
+++ b/core/src/engine/diffseek-engine.ts
@@ -9,6 +9,7 @@ import { processDiffElements, serializeTokens, cleanupUnusedMarkers } from "./pr
 import type { DiffContext, DiffseekEventMap, DiffVisibilityChangeEntry, DiffWorkflowStatus, MarkerElementsMap, SelectionChangeData } from "./types";
 import type { EditorName } from "../editor";
 import type { DiffOptions } from "../diff/types";
+import { TOKEN_BUFFER_STRIDE } from "../constants";
 import type { DiffseekOptions, Palette, Span } from "../types";
 import { DEFAULT_PALETTE } from "../palette/default-palette";
 import { Renderer } from "../renderer/renderer";
@@ -466,6 +467,120 @@ export class DiffseekEngine {
 
     setHoveredDiff(diffIndex: number | null) {
         this.renderer.setHoveredDiffIndex(diffIndex);
+    }
+
+    getTextForTokenSpan(side: EditorName, span: Span): string | null {
+        if (!this.diffContext) return null;
+        const tokens = side === "left" ? this.diffContext.leftTokens : this.diffContext.rightTokens;
+        if (span.start < 0 || span.end > tokens.length || span.start >= span.end) return null;
+        const editor = side === "left" ? this.leftEditor : this.rightEditor;
+        const wholeText = editor.wholeText;
+        let result = "";
+        for (let i = span.start; i < span.end; i++) {
+            const token = tokens[i];
+            if (token.flags & 0x2 /* TOKEN_FLAGS_TYPE_IMAGE */) continue;
+            const start = token.textOffset;
+            const end = i + 1 < tokens.length
+                ? tokens[i + 1].textOffset
+                : token.textOffset + token.textLength;
+            result += wholeText.slice(start, end);
+        }
+        return result;
+    }
+
+    /**
+     * 좌우 매칭 span을 토큰 단위 최소 매칭 쌍으로 분쇄.
+     * 입력은 resolveMatchingSpanPair의 결과(토큰 인덱스 span)여야 하지만 강제하지 않음.
+     */
+    segmentSpanPair(leftSpan: Span, rightSpan: Span): { left: Span | null; right: Span | null }[] {
+        if (!this.diffContext) return [];
+        const S = TOKEN_BUFFER_STRIDE;
+        const lBuf = this.diffContext.leftTokenBuffer;
+        const rBuf = this.diffContext.rightTokenBuffer;
+        const segments: { left: Span | null; right: Span | null }[] = [];
+
+        let li = leftSpan.start;
+        let ri = rightSpan.start;
+
+        while (li < leftSpan.end || ri < rightSpan.end) {
+            if (li >= leftSpan.end) {
+                // 좌측 소진 — 남은 우측을 하나의 segment로
+                segments.push({ left: null, right: { start: ri, end: rightSpan.end } });
+                break;
+            }
+            if (ri >= rightSpan.end) {
+                // 우측 소진 — 남은 좌측을 하나의 segment로
+                segments.push({ left: { start: li, end: leftSpan.end }, right: null });
+                break;
+            }
+
+            // 현재 좌측 토큰의 반대편 매칭 범위
+            const lOppStart = lBuf[li * S + 2];
+            const lOppEnd = lBuf[li * S + 3];
+
+            // 현재 우측 토큰의 반대편 매칭 범위
+            const rOppStart = rBuf[ri * S + 2];
+            const rOppEnd = rBuf[ri * S + 3];
+
+            // 좌측 토큰이 우측 범위 밖을 가리킴 → 좌측만 있는 segment
+            if (lOppStart >= rightSpan.end || lOppEnd <= ri) {
+                const segStart = li;
+                li++;
+                while (li < leftSpan.end) {
+                    const nextOppStart = lBuf[li * S + 2];
+                    if (nextOppStart >= ri) break;
+                    li++;
+                }
+                segments.push({ left: { start: segStart, end: li }, right: null });
+                continue;
+            }
+
+            // 우측 토큰이 좌측 범위 밖을 가리킴 → 우측만 있는 segment
+            if (rOppStart >= leftSpan.end || rOppEnd <= li) {
+                const segStart = ri;
+                ri++;
+                while (ri < rightSpan.end) {
+                    const nextOppStart = rBuf[ri * S + 2];
+                    if (nextOppStart >= li) break;
+                    ri++;
+                }
+                segments.push({ left: null, right: { start: segStart, end: ri } });
+                continue;
+            }
+
+            // 양쪽 매칭 — 그룹 확장
+            let lEnd = li + 1;
+            let rEnd = Math.max(ri + 1, lOppEnd);
+
+            // 우측 끝에 해당하는 좌측 범위가 더 넓을 수 있으므로 수렴할 때까지 반복
+            let changed = true;
+            while (changed) {
+                changed = false;
+                // 우측 끝까지의 좌측 범위 확장
+                for (let r = ri; r < rEnd && r < rightSpan.end; r++) {
+                    const oppEnd = rBuf[r * S + 3];
+                    if (oppEnd > lEnd) { lEnd = oppEnd; changed = true; }
+                }
+                // 좌측 끝까지의 우측 범위 확장
+                for (let l = li; l < lEnd && l < leftSpan.end; l++) {
+                    const oppEnd = lBuf[l * S + 3];
+                    if (oppEnd > rEnd) { rEnd = oppEnd; changed = true; }
+                }
+            }
+
+            lEnd = Math.min(lEnd, leftSpan.end);
+            rEnd = Math.min(rEnd, rightSpan.end);
+
+            segments.push({
+                left: { start: li, end: lEnd },
+                right: { start: ri, end: rEnd },
+            });
+
+            li = lEnd;
+            ri = rEnd;
+        }
+
+        return segments;
     }
 
     getUserSelectionRange(): { editor: Editor; range: Range } | { editor: null; range: null } {

--- a/core/src/renderer/editor-region.ts
+++ b/core/src/renderer/editor-region.ts
@@ -39,12 +39,6 @@ export class EditorRegion {
 
         let ret: number = 0;
         if (this.regionX !== x || this.regionY !== y || this.regionWidth !== width || this.regionHeight !== height) {
-            if (import.meta.env.DEV) {
-                console.debug(
-                    `[EditorRegion:${this.editor.name}] layout changed → DIRTY_RESIZE+GEOMETRY:`,
-                    `x ${this.regionX}→${x}, y ${this.regionY}→${y}, w ${this.regionWidth}→${width}, h ${this.regionHeight}→${height}`,
-                );
-            }
             renderer.invalidateGeometries(this.editor.name);
             ret = DIRTY_RESIZE;
         } else if (this.#scrollTop !== scrollTop) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
       "name": "diffseek-app",
       "version": "0.0.0",
       "dependencies": {
-        "@mantine/core": "^8.3.13",
-        "@mantine/hooks": "^8.3.13",
+        "@mantine/core": "^9.0.0",
+        "@mantine/hooks": "^9.0.0",
         "@tabler/icons-react": "^3.36.1",
         "clsx": "^2.1.1",
         "diffseek-core": "*",
@@ -39,6 +39,34 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "esbuild": "^0.27.4",
         "vite": "^8.0.1"
+      }
+    },
+    "app/node_modules/@mantine/core": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.0.0.tgz",
+      "integrity": "sha512-GUUXlf+4uDpRu5iZ1PFy1NmgG7ttI+1I6VTw3v/b7N1jwOUhARwL1moGjPMjo3Eie3tHdVOCiVMYAvhlQ1GI5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.19",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.5",
+        "react-remove-scroll": "^2.7.2",
+        "type-fest": "^5.5.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "9.0.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
+    "app/node_modules/@mantine/hooks": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.0.0.tgz",
+      "integrity": "sha512-TKcz+k0JH/jtblBfwOw/vXBX2EpJO66psJ5ZVmdDhwc6vbHDsvY6oYN8ynt9TfRn/eHZXsEmLPNj+wuGtWy4BA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "app/node_modules/@rolldown/plugin-babel": {
@@ -104,6 +132,21 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "app/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "core": {
@@ -366,15 +409,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1076,32 +1110,32 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.17",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.17.tgz",
-      "integrity": "sha512-LGVZKHwmWGg6MRHjLLgsfyaX2y2aCNgnD1zT/E6B+/h+vxg+nIJUqHPAlTzsHDyqdgEpJ1Np5kxWuFEErXzoGg==",
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.7",
-        "@floating-ui/utils": "^0.2.10",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
@@ -1110,12 +1144,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.5"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1123,9 +1157,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -1194,35 +1228,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mantine/core": {
-      "version": "8.3.13",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.13.tgz",
-      "integrity": "sha512-ZgW4vqN4meaPyIMxzAufBvsgmJRfYZdTpsrAOcS8pWy7m9e8i685E7XsAxnwJCOIHudpvpvt+7Bx7VaIjEsYEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "^0.27.16",
-        "clsx": "^2.1.1",
-        "react-number-format": "^5.4.4",
-        "react-remove-scroll": "^2.7.1",
-        "react-textarea-autosize": "8.5.9",
-        "type-fest": "^4.41.0"
-      },
-      "peerDependencies": {
-        "@mantine/hooks": "8.3.13",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
-      }
-    },
-    "node_modules/@mantine/hooks": {
-      "version": "8.3.13",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.13.tgz",
-      "integrity": "sha512-7YMbMW/tR9E8m/9DbBW01+3RNApm2mE/JbRKXf9s9+KxgbjQvq0FYGWV8Y4+Sjz48AO4vtWk2qBriUTgBMKAyg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3415,9 +3420,9 @@
       }
     },
     "node_modules/react-number-format": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
-      "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -3491,23 +3496,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -3866,6 +3854,18 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -4005,18 +4005,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4093,51 +4081,6 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-composed-ref": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {


### PR DESCRIPTION
## Summary

- `Intl.Segmenter` grapheme 단위 LCS diff 알고리즘 구현
- 드래그 선택 후 메뉴 팝오버 → Diff 클릭 → 결과 팝오버 (FloatingWindow)
- `Alt+Q` 단축키로 직접 실행
- `segmentSpanPair`로 토큰 매��� 경계를 존중하는 segment별 char diff
- inline / side-by-side / stacked 3가지 뷰 모드
- 자동 ���트 크기 조절 (inline 모드, binary search)
- 드래그 이동 + 리사이즈 + ESC/닫기 버튼
- Mantine 8 → 9 업그레이드

Closes #81