### PR TITLE
fix: prevent spurious scrollbar on editor-content in sync mode

### DIFF
--- a/core/src/core.css
+++ b/core/src/core.css
@@ -159,8 +159,7 @@
   min-width: 0;
   max-width: 100%;
   min-height: 100%;
-  overflow-x: hidden;
-  overflow-y: visible;
+  overflow: hidden;
   font-size: var(--ds-base-font-size);
   padding: var(--ds-content-padding);
   scroll-padding-top: calc(3em * var(--ds-line-height));


### PR DESCRIPTION
CSS spec computes overflow-y: visible → auto when overflow-x: hidden,
causing scrollbars on the content element when min-height is unset in
sync mode. Use overflow: hidden since this element should never
independently scroll (parent .ds-editor is the scroll container).

https://claude.ai/code/session_01Kt6WamjVd2yJyfngMg8sbm