### PR TITLE
feat: merge section heading patterns globally, not just at line start

### DIFF
--- a/core/src/tokenization/tokenize.ts
+++ b/core/src/tokenization/tokenize.ts
@@ -560,17 +560,20 @@ export async function tokenize(root: HTMLElement, signal: AbortSignal, options: 
 
                 collapsable = false;
 
-                if (!tokenStartPos && (nextTokenFlags & TOKEN_FLAGS_LINE_START) && (meta & CM_HEADING_START)) {
+                if (!tokenStartPos && (meta & CM_HEADING_START)) {
                     const headingStartPos = cursor.getPos();
-                    const match = tryMatchSectionHeading(cursor, code, allowStandaloneLawArticle);
+                    const isLineStart = !!(nextTokenFlags & TOKEN_FLAGS_LINE_START);
+                    const match = tryMatchSectionHeading(cursor, code, allowStandaloneLawArticle, isLineStart);
                     if (match) {
                         const headingEndPos = cursor.getPos();
-                        nextTokenFlags |= (match.type << PAYLOAD_SHIFT) | TOKEN_FLAGS_IS_HEADING;
+                        if (isLineStart) {
+                            nextTokenFlags |= (match.type << PAYLOAD_SHIFT) | TOKEN_FLAGS_IS_HEADING;
+                            sectionHeadings.push({ ...match, tokenIndex: tokens.length });
+                        }
                         addToken(TOKEN_FLAGS_TYPE_TEXT, match.text, TOKEN_FLAGS_WORD_LIKE,
                             textNodeBuf[headingStartPos.nodeIndex], headingStartPos.charIndex,
                             textNodeBuf[headingEndPos.nodeIndex], headingEndPos.charIndex,
                         );
-                        sectionHeadings.push({ ...match, tokenIndex: tokens.length - 1 });
                         continue;
                     }
                 }

--- a/core/src/tokenization/try-match-section-heading.ts
+++ b/core/src/tokenization/try-match-section-heading.ts
@@ -67,7 +67,7 @@ function tryMatchLawArticle(cursor: TextNodeCursor): NumberingMatch | null {
         cursor.moveNext(); // cursor: 조 → 의
         code = skipOptionalWs(cursor); // 의 소비, 공백 최대 1개 건너뜀 ("조의 2" 허용)
         if (code >= 0x30 && code <= 0x39) {
-            // cursor는 이미 첫 숫자에 위치 (skipWs가 전진함)
+            // cursor는 이미 첫 숫자에 위치 (skipOptionalWs가 전진함)
             subNumber = parseAsciiNumber(cursor, code);
             if (!subNumber) return null;
             code = cursor.current; // parseAsciiNumber가 종결자까지 전진함

--- a/core/src/tokenization/try-match-section-heading.ts
+++ b/core/src/tokenization/try-match-section-heading.ts
@@ -37,7 +37,7 @@ function tryMatchLawArticle(cursor: TextNodeCursor): NumberingMatch | null {
     let code: number = -1;
     let meta: number = 0;
 
-    code = skipWs(cursor);
+    code = skipOptionalWs(cursor);
     if (code < 0x30 || code > 0x39) {
         return null;
     }
@@ -51,7 +51,8 @@ function tryMatchLawArticle(cursor: TextNodeCursor): NumberingMatch | null {
     meta = CHAR_META[code];
 
     if (meta & CM_WS) {
-        code = skipWs(cursor);
+        if (!cursor.moveNext()) return null;
+        code = cursor.current;
     }
 
     if (code !== 0xc870) { // 조
@@ -64,7 +65,7 @@ function tryMatchLawArticle(cursor: TextNodeCursor): NumberingMatch | null {
     let subNumber: number | null = null;
     if (code === 0xc758) { // 의
         cursor.moveNext(); // cursor: 조 → 의
-        code = skipWs(cursor); // 의 소비, 공백 건너뜀 ("조의 2" 허용)
+        code = skipOptionalWs(cursor); // 의 소비, 공백 최대 1개 건너뜀 ("조의 2" 허용)
         if (code >= 0x30 && code <= 0x39) {
             // cursor는 이미 첫 숫자에 위치 (skipWs가 전진함)
             subNumber = parseAsciiNumber(cursor, code);
@@ -105,13 +106,8 @@ function tryMatchParenthesized(cursor: TextNodeCursor): NumberingMatch | null {
     let code: number = -1;
     let meta: number = 0;
 
-    while (cursor.moveNext()) {
-        code = cursor.current;
-        meta = CHAR_META[code];
-        if (!(meta & CM_WS)) {
-            break;
-        }
-    }
+    code = skipOptionalWs(cursor);
+    if (code === -1) return null;
 
     const number = parseOrdinal(cursor, code);
     if (!number) {
@@ -121,13 +117,8 @@ function tryMatchParenthesized(cursor: TextNodeCursor): NumberingMatch | null {
     code = cursor.current;
     meta = CHAR_META[code];
     if (meta & CM_WS) {
-        while (cursor.moveNext()) {
-            code = cursor.current;
-            meta = CHAR_META[code];
-            if (!(meta & CM_WS)) {
-                break;
-            }
-        }
+        if (!cursor.moveNext()) return null;
+        code = cursor.current;
     }
 
     if (code !== 0x29) { // )
@@ -152,10 +143,16 @@ function tryMatchNumberWithSuffix(cursor: TextNodeCursor): NumberingMatch | null
     let meta: number = CHAR_META[code];
 
     if (meta & CM_WS) {
-        code = skipWs(cursor);
+        if (!cursor.moveNext()) return null;
+        code = cursor.current;
     }
 
     if (code === 0x2e) { // .
+        // false positive 보호: 1.5 같은 소수점 방지
+        const peek = cursor.peek();
+        if (peek >= 0x30 && peek <= 0x39) {
+            return null;
+        }
         number.text = `${number.text}.`;
         // 접미 문자를 소비해서 중복 토큰 생성을 방지한다.
         cursor.moveNext();
@@ -180,7 +177,7 @@ function scanHasWordLike(cursor: TextNodeCursor): boolean {
     return false;
 }
 
-export function tryMatchSectionHeading(cursor: TextNodeCursor, firstCharCode: number, allowStandaloneLawArticle = false): SectionHeadingMatch | null {
+export function tryMatchSectionHeading(cursor: TextNodeCursor, firstCharCode: number, allowStandaloneLawArticle = false, requireWordLike = true): SectionHeadingMatch | null {
     const start = cursor.getPos();
     let match: NumberingMatch | null = null;
 
@@ -196,13 +193,15 @@ export function tryMatchSectionHeading(cursor: TextNodeCursor, firstCharCode: nu
 
     if (match) {
         const headingEndPos = cursor.getPos();
-        // LAW_ARTICLE(제N조)은 줄 시작에 나오는 것 자체가 강한 신호이므로
-        // allowStandaloneLawArticle 옵션이 켜져 있으면 word-like 검사를 건너뛴다.
-        if (!(allowStandaloneLawArticle && match.type === SECTION_HEADING_TYPE_LAW_ARTICLE)) {
-            const hasWordLike = scanHasWordLike(cursor);
-            if (!hasWordLike) {
-                cursor.moveTo(start);
-                return null;
+        if (requireWordLike) {
+            // LAW_ARTICLE(제N조)은 줄 시작에 나오는 것 자체가 강한 신호이므로
+            // allowStandaloneLawArticle 옵션이 켜져 있으면 word-like 검사를 건너뛴다.
+            if (!(allowStandaloneLawArticle && match.type === SECTION_HEADING_TYPE_LAW_ARTICLE)) {
+                const hasWordLike = scanHasWordLike(cursor);
+                if (!hasWordLike) {
+                    cursor.moveTo(start);
+                    return null;
+                }
             }
         }
         cursor.moveTo(headingEndPos);
@@ -257,14 +256,13 @@ function parseAsciiNumber(cursor: TextNodeCursor, firstCode: number): number | n
     return number;
 }
 
-function skipWs(cursor: TextNodeCursor): number {
-    let code = -1;
-    let meta = 0;
-
-    while (cursor.moveNext()) {
+/** 공백을 최대 1개만 건너뜀 (0 or 1). */
+function skipOptionalWs(cursor: TextNodeCursor): number {
+    if (!cursor.moveNext()) return -1;
+    let code = cursor.current;
+    if (CHAR_META[code] & CM_WS) {
+        if (!cursor.moveNext()) return -1;
         code = cursor.current;
-        meta = CHAR_META[code];
-        if (!(meta & CM_WS)) break;
     }
     return code;
 }

--- a/core/tests/tokenizer.test.ts
+++ b/core/tests/tokenizer.test.ts
@@ -225,10 +225,57 @@ describe('section heading tokenization', () => {
         expect(sectionHeadings).toHaveLength(0);
     });
 
-    // ─── 줄 중간은 헤딩 아님 ─────────────────────────────────────────────────
+    // ─── 줄 중간 패턴 병합 (헤딩 플래그 없음) ──────────────────────────────────
 
-    it('줄 중간에 나오는 "1."은 헤딩 아님', async () => {
-        const { sectionHeadings } = await tok('<div>ABC 1. 내용</div>');
+    it('줄 중간 "1."은 패턴 병합되지만 헤딩 아님', async () => {
+        const { texts, sectionHeadings } = await tok('<div>ABC 1. 내용</div>');
+        expect(texts).toContain('1.');
+        expect(sectionHeadings).toHaveLength(0);
+    });
+
+    it('줄 중간 "(1)"은 패턴 병합되지만 헤딩 아님', async () => {
+        const { texts, sectionHeadings } = await tok('<div>ABC (1) 내용</div>');
+        expect(texts).toContain('(1)');
+        expect(sectionHeadings).toHaveLength(0);
+    });
+
+    it('줄 중간 "제1조"는 패턴 병합되지만 헤딩 아님', async () => {
+        const { texts, sectionHeadings } = await tok('<div>ABC 제1조 내용</div>');
+        expect(texts).toContain('제1조');
+        expect(sectionHeadings).toHaveLength(0);
+    });
+
+    it('줄 중간 병합 토큰에는 HEADING_MASK 없음', async () => {
+        const { tokens, texts } = await tok('<div>ABC (1) 내용</div>');
+        const idx = texts.indexOf('(1)');
+        expect(idx).toBeGreaterThan(0);
+        expect(tokens[idx].flags & HEADING_MASK).toBe(0);
+    });
+
+    // ─── false positive 보호 ──────────────────────────────────────────────────
+
+    it('"1.5" — 소수점이므로 병합하지 않음', async () => {
+        const { texts } = await tok('<div>1.5 내용</div>');
+        expect(texts).not.toContain('1.');
+        expect(texts[0]).toBe('1');
+    });
+
+    it('줄 중간 "1.5" — 소수점이므로 병합하지 않음', async () => {
+        const { texts } = await tok('<div>ABC 1.5 내용</div>');
+        expect(texts).not.toContain('1.');
+    });
+
+    // ─── 공백 규칙 강화 (공백? — 최대 1개) ────────────────────────────────────
+
+    it('"제  1  조" — 공백 2개 이상이면 병합하지 않음', async () => {
+        const { texts, sectionHeadings } = await tok('<div>제  1  조 제목</div>');
+        expect(texts).not.toContain('제1조');
+        expect(sectionHeadings).toHaveLength(0);
+    });
+
+    it('"(  1  )" — 공백 2개 이상이면 병합하지 않음', async () => {
+        const { texts, sectionHeadings } = await tok('<div>(  1  ) 제목</div>');
+        expect(texts).not.toContain('(1)');
         expect(sectionHeadings).toHaveLength(0);
     });
 


### PR DESCRIPTION
Section heading tokens like (1), 제1조, 1. were only merged into single
tokens at line start, causing diff mismatch with identical text mid-line.

Changes:
- Remove line-start requirement for heading pattern merge in tokenize.ts
- Keep heading FLAGS (IS_HEADING, type bits) only for line-start headings
- Tighten whitespace rules: max 1 space between heading parts (was unlimited)
- Add false positive protection: N. followed by digit (e.g. 1.5) is not merged
- Add requireWordLike parameter to tryMatchSectionHeading (true at line start,
  false at mid-line positions)

https://claude.ai/code/session_01RjPKA7UR4tZPdYUEtJ93MA