### PR TITLE
Fix plain text vs HTML table diff matching

### DIFF
--- a/core/src/diff/run-histogram-diff.ts
+++ b/core/src/diff/run-histogram-diff.ts
@@ -192,7 +192,7 @@ export async function runHistogramDiff(
             localLcpScratch = new Uint32Array(requiredSize);
             localIdsScratch = new Uint32Array(requiredSize);
         }
-        const cntSize = Math.max(requiredSize + 2, maxId + 2);
+        const cntSize = Math.max(requiredSize + 2, maxId + 3);
         if (localCntScratch.length < cntSize) {
             localCntScratch = new Uint32Array(cntSize);
         }
@@ -226,8 +226,10 @@ export async function runHistogramDiff(
         const rhsLoG = _pivot + rhsLower;
         const rhsHiG = _pivot + rhsUpper;
 
-        const m = lhsRange + rhsRange;
-        if (m < 2) return { anchor: null, rank: null };
+        // LHS와 RHS 사이에 sentinel을 삽입하여 경계를 넘는 LCP 매칭을 차단
+        const sentinelId = maxId + 1;
+        const m = lhsRange + 1 + rhsRange;
+        if (m < 3) return { anchor: null, rank: null }; // lhsRange + rhsRange < 2
 
         // 서브영역 토큰만으로 SA/LCP를 스크래치 빌드
         ensureLocalScratchCapacity(m);
@@ -240,31 +242,19 @@ export async function runHistogramDiff(
             const cnt_l = localCntScratch;
             const ids_l = localIdsScratch.subarray(0, m);
 
-            // 1) ID를 연속 배열에 복사 + rank 초기화
+            // 1) ID를 연속 배열에 복사: [LHS tokens, sentinel, RHS tokens]
             for (let ii = 0; ii < lhsRange; ii++) ids_l[ii] = _lhsIds[lhsLower + ii];
-            for (let ii = 0; ii < rhsRange; ii++) ids_l[lhsRange + ii] = _rhsIds[rhsLower + ii];
+            ids_l[lhsRange] = sentinelId;
+            for (let ii = 0; ii < rhsRange; ii++) ids_l[lhsRange + 1 + ii] = _rhsIds[rhsLower + ii];
 
             let maxRank: number;
-            if (parentRank && parentLhsLower !== undefined && parentRhsLower !== undefined && parentLhsRange !== undefined) {
-                // 부모 rank를 초기값으로 사용 → doubling 반복 횟수 대폭 감소
-                for (let ii = 0; ii < lhsRange; ii++) {
-                    rank_l[ii] = parentRank[(lhsLower + ii) - parentLhsLower];
-                }
-                for (let ii = 0; ii < rhsRange; ii++) {
-                    rank_l[lhsRange + ii] = parentRank[parentLhsRange + (rhsLower + ii) - parentRhsLower];
-                }
-                maxRank = 0;
-                for (let ii = 0; ii < m; ii++) {
-                    sa_l[ii] = ii;
-                    if (rank_l[ii] > maxRank) maxRank = rank_l[ii];
-                }
-            } else {
-                // 최초 호출: 원본 ID를 rank로 사용
+            // 원본 ID를 rank로 사용
+            {
                 for (let ii = 0; ii < m; ii++) {
                     sa_l[ii] = ii;
                     rank_l[ii] = ids_l[ii];
                 }
-                maxRank = maxId;
+                maxRank = sentinelId;
             }
 
             // 2) Doubling + Counting Sort
@@ -325,12 +315,17 @@ export async function runHistogramDiff(
                 lcp_l[r - 1] = h_k;
             }
 
-            // 4) local SA → global position 변환
+            // 4) local SA → global position 변환 (sentinel 위치는 그대로 유지)
             for (let ii = 0; ii < m; ii++) {
                 const lp = sa_l[ii];
-                sa_l[ii] = lp < lhsRange
-                    ? lhsLower + lp
-                    : _pivot + rhsLower + (lp - lhsRange);
+                if (lp < lhsRange) {
+                    sa_l[ii] = lhsLower + lp;
+                } else if (lp === lhsRange) {
+                    // sentinel — LHS/RHS 어느 범위에도 속하지 않는 값
+                    sa_l[ii] = rhsHiG;
+                } else {
+                    sa_l[ii] = _pivot + rhsLower + (lp - lhsRange - 1);
+                }
             }
         }
 

--- a/core/src/tokenization/tokenize.ts
+++ b/core/src/tokenization/tokenize.ts
@@ -734,7 +734,12 @@ export async function tokenize(root: HTMLElement, signal: AbortSignal, options: 
         }
 
         if (tokens.length > 0) {
-            tokens[tokens.length - 1].flags |= TOKEN_FLAGS_LINE_END;
+            // 마지막 텍스트 토큰에 LINE_END 설정.
+            // 구조적 토큰은 lastToken을 갱신하지 않으므로,
+            // tokens[length-1]이 구조적 토큰이면 마지막 텍스트 토큰을 놓침.
+            if (lastToken) {
+                lastToken.flags |= TOKEN_FLAGS_LINE_END;
+            }
             if (wholeTextLastChar !== 10 /* \n */) {
                 wholeTextBuf.push("\n");
                 wholeTextLastChar = 10 /* \n */;

--- a/core/tests/loan-table-diff.test.ts
+++ b/core/tests/loan-table-diff.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Plain text vs HTML table diff 테스트
+ *
+ * Left: "1.대출개요 개인택시" (plain text)
+ * Right: <table><tr><td>1.대출개요</td><td>개인택시</td></tr></table>
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { TOKEN_BUFFER_STRIDE } from "../src/constants";
+import { buildDiffInput } from "../src/diff/build-diff-input";
+import { buildDiffScoreSystem } from "../src/diff/build-diff-score-system";
+import { getDefaultDiffOptions } from "../src/diff/get-default-diff-options";
+import { runHistogramDiff } from "../src/diff/run-histogram-diff";
+import { DIFF_TYPE_ADDED, DIFF_TYPE_REMOVED, DIFF_TYPE_UNCHANGED } from "../src/diff/types";
+import { tokenize } from "../src/tokenization/tokenize";
+import { TOKEN_FLAGS_LINE_END, TOKEN_FLAGS_TYPE_STRUCTURAL } from "../src/tokenization/token-flags";
+import { processDiffElements } from "../src/engine/process-diff-elements";
+import type { Token } from "../src/tokenization";
+import type { TokenSnapshot } from "../src/editor/editor";
+import type { MarkerElementsMap } from "../src/engine/types";
+
+beforeAll(() => {
+    if (typeof (globalThis as any).scheduler?.yield !== "function") {
+        (globalThis as any).scheduler = {
+            ...(globalThis as any).scheduler,
+            yield: () => Promise.resolve(),
+        };
+    }
+});
+
+// ── helpers ──────────────────────────────────────────────────────
+
+const PLAIN_TEXT = "1.대출개요 개인택시";
+const TABLE_HTML = "<table><tr><td>1.대출개요</td><td>개인택시</td></tr></table>";
+
+async function tokenizeHtml(html: string) {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    const signal = new AbortController().signal;
+    const result = await tokenize(el, signal);
+    return { el, ...result };
+}
+
+async function makeInputFromHtml(html: string) {
+    const div = document.createElement("div");
+    div.innerHTML = html;
+    const signal = new AbortController().signal;
+    const { tokens, wholeText } = await tokenize(div, signal);
+
+    const data = new Int32Array(tokens.length * TOKEN_BUFFER_STRIDE);
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i]!;
+        data[i * TOKEN_BUFFER_STRIDE + 0] = t.textOffset;
+        data[i * TOKEN_BUFFER_STRIDE + 1] = t.textLength;
+        data[i * TOKEN_BUFFER_STRIDE + 2] = t.flags;
+    }
+
+    return { tokens, wholeText, ...buildDiffInput(wholeText, data, getDefaultDiffOptions()).input };
+}
+
+function readType(resultBuffer: Int32Array, i: number) {
+    return resultBuffer[i * TOKEN_BUFFER_STRIDE + 4]!;
+}
+
+function readRange(resultBuffer: Int32Array, i: number) {
+    const base = i * TOKEN_BUFFER_STRIDE;
+    return {
+        selfStart: resultBuffer[base + 0]!,
+        selfEnd: resultBuffer[base + 1]!,
+        otherStart: resultBuffer[base + 2]!,
+        otherEnd: resultBuffer[base + 3]!,
+        type: resultBuffer[base + 4]!,
+    };
+}
+
+function getTokenText(tokens: Token[], wholeText: string, i: number): string {
+    const t = tokens[i]!;
+    return wholeText.slice(t.textOffset, t.textOffset + t.textLength);
+}
+
+function makeSnapshot(tokenizeResult: Awaited<ReturnType<typeof tokenizeHtml>>): TokenSnapshot {
+    return {
+        wholeText: tokenizeResult.wholeText,
+        tokens: tokenizeResult.tokens,
+        lineBoundaries: tokenizeResult.lineBoundaries,
+        sectionHeadings: tokenizeResult.sectionHeadings,
+        containers: tokenizeResult.containers,
+        elapsedTime: 0,
+    };
+}
+
+function makeMockEditor(tokens: Token[], contentEl: HTMLElement) {
+    return {
+        contentElement: contentEl,
+        tokens,
+        getTokenRange(start: number, end: number) {
+            while (start < end && (tokens[start]?.flags & TOKEN_FLAGS_TYPE_STRUCTURAL)) start++;
+            while (end > start && (tokens[end - 1]?.flags & TOKEN_FLAGS_TYPE_STRUCTURAL)) end--;
+
+            const range = document.createRange();
+            const count = end - start;
+            if (count > 0 && start < tokens.length) {
+                range.setStart(tokens[start].startNode, tokens[start].startOffset);
+                if (end - 1 < tokens.length) {
+                    range.setEnd(tokens[end - 1].endNode, tokens[end - 1].endOffset);
+                } else {
+                    range.setEnd(contentEl, contentEl.childNodes.length);
+                }
+            } else {
+                if (start > 0 && start - 1 < tokens.length) {
+                    range.setStart(tokens[start - 1].endNode, tokens[start - 1].endOffset);
+                } else {
+                    range.setStart(contentEl, 0);
+                }
+                range.collapse(true);
+            }
+            return range;
+        },
+    } as any;
+}
+
+async function runFullPipeline(leftHtml: string, rightHtml: string) {
+    const leftTokenized = await tokenizeHtml(leftHtml);
+    const rightTokenized = await tokenizeHtml(rightHtml);
+
+    const { input: lhsInput } = buildDiffInput(
+        leftTokenized.wholeText,
+        serializeTokens(leftTokenized.tokens),
+        getDefaultDiffOptions(),
+    );
+    const { input: rhsInput } = buildDiffInput(
+        rightTokenized.wholeText,
+        serializeTokens(rightTokenized.tokens),
+        getDefaultDiffOptions(),
+    );
+
+    await runHistogramDiff({
+        reqId: 1,
+        diffOptions: getDefaultDiffOptions(),
+        score: buildDiffScoreSystem(),
+        signal: new AbortController().signal,
+    }, lhsInput, rhsInput, 0, 0);
+
+    const leftSnapshot = makeSnapshot(leftTokenized);
+    const rightSnapshot = makeSnapshot(rightTokenized);
+    const leftEditor = makeMockEditor(leftTokenized.tokens, leftTokenized.el);
+    const rightEditor = makeMockEditor(rightTokenized.tokens, rightTokenized.el);
+
+    const markerElements: MarkerElementsMap = new Map();
+
+    const diffContext = await processDiffElements({
+        leftEditor,
+        rightEditor,
+        leftTokenSnapshot: leftSnapshot,
+        rightTokenSnapshot: rightSnapshot,
+        diffOptions: getDefaultDiffOptions(),
+        result: {
+            leftResultBuffer: lhsInput.resultBuffer,
+            rightResultBuffer: rhsInput.resultBuffer,
+            elapsedTime: 0,
+        },
+        markerElements,
+        prevMarkerElements: null,
+    });
+
+    return {
+        diffContext,
+        leftEl: leftTokenized.el,
+        rightEl: rightTokenized.el,
+        leftTokens: leftTokenized.tokens,
+        rightTokens: rightTokenized.tokens,
+    };
+}
+
+function serializeTokens(tokens: Token[]) {
+    const data = new Int32Array(tokens.length * TOKEN_BUFFER_STRIDE);
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i]!;
+        data[i * TOKEN_BUFFER_STRIDE + 0] = t.textOffset;
+        data[i * TOKEN_BUFFER_STRIDE + 1] = t.textLength;
+        data[i * TOKEN_BUFFER_STRIDE + 2] = t.flags;
+    }
+    return data;
+}
+
+// ── tests ────────────────────────────────────────────────────────
+
+describe("plain text vs table: tokenization", () => {
+
+    it("last text token in each TD has LINE_END", async () => {
+        const result = await tokenizeHtml(TABLE_HTML);
+        // 각 TD의 마지막 텍스트 토큰 찾기
+        const textTokens = result.tokens
+            .map((t, i) => ({ ...t, i }))
+            .filter(t => !(t.flags & TOKEN_FLAGS_TYPE_STRUCTURAL));
+
+        // "대출개요" — 첫 번째 TD의 마지막 텍스트
+        const token_대출개요 = textTokens.find(t =>
+            result.wholeText.slice(t.textOffset, t.textOffset + t.textLength) === "대출개요"
+        );
+        expect(token_대출개요, "대출개요 토큰이 존재해야 함").toBeTruthy();
+        expect(token_대출개요!.flags & TOKEN_FLAGS_LINE_END, "대출개요에 LINE_END 필요").toBeTruthy();
+
+        // "개인택시" — 두 번째 TD의 마지막 텍스트
+        const token_개인택시 = textTokens.find(t =>
+            result.wholeText.slice(t.textOffset, t.textOffset + t.textLength) === "개인택시"
+        );
+        expect(token_개인택시, "개인택시 토큰이 존재해야 함").toBeTruthy();
+        expect(token_개인택시!.flags & TOKEN_FLAGS_LINE_END, "개인택시에 LINE_END 필요").toBeTruthy();
+    });
+});
+
+describe("plain text vs table: histogram diff", () => {
+
+    it("shared text content is matched as UNCHANGED", async () => {
+        const lhs = await makeInputFromHtml(PLAIN_TEXT);
+        const rhs = await makeInputFromHtml(TABLE_HTML);
+
+        await runHistogramDiff({
+            reqId: 1,
+            diffOptions: getDefaultDiffOptions(),
+            score: buildDiffScoreSystem(),
+            signal: new AbortController().signal,
+        }, lhs, rhs);
+
+        // 왼쪽의 텍스트 토큰 중 UNCHANGED인 것들의 텍스트를 수집
+        const unchangedTexts: string[] = [];
+        for (let i = 0; i < lhs.tokens.length; i++) {
+            if (lhs.tokens[i]!.flags & TOKEN_FLAGS_TYPE_STRUCTURAL) continue;
+            if (readType(lhs.resultBuffer, i) === DIFF_TYPE_UNCHANGED) {
+                unchangedTexts.push(getTokenText(lhs.tokens, lhs.wholeText, i));
+            }
+        }
+
+        const joined = unchangedTexts.join("");
+        // 대출개요와 개인택시 둘 다 매칭되어야 함
+        expect(joined, `UNCHANGED texts: [${unchangedTexts.join(", ")}]`).toContain("대출개요");
+        expect(joined, `UNCHANGED texts: [${unchangedTexts.join(", ")}]`).toContain("개인택시");
+    });
+
+    it("right-side structural tokens are not UNCHANGED (no matching structure on left)", async () => {
+        const lhs = await makeInputFromHtml(PLAIN_TEXT);
+        const rhs = await makeInputFromHtml(TABLE_HTML);
+
+        await runHistogramDiff({
+            reqId: 1,
+            diffOptions: getDefaultDiffOptions(),
+            score: buildDiffScoreSystem(),
+            signal: new AbortController().signal,
+        }, lhs, rhs);
+
+        for (let i = 0; i < rhs.tokens.length; i++) {
+            if (rhs.tokens[i]!.flags & TOKEN_FLAGS_TYPE_STRUCTURAL) {
+                const type = readType(rhs.resultBuffer, i);
+                expect(type, `rhs structural token[${i}] should not be UNCHANGED`).not.toBe(DIFF_TYPE_UNCHANGED);
+            }
+        }
+    });
+
+    it("resultBuffer ranges are self-consistent on both sides", async () => {
+        const lhs = await makeInputFromHtml(PLAIN_TEXT);
+        const rhs = await makeInputFromHtml(TABLE_HTML);
+
+        await runHistogramDiff({
+            reqId: 1,
+            diffOptions: getDefaultDiffOptions(),
+            score: buildDiffScoreSystem(),
+            signal: new AbortController().signal,
+        }, lhs, rhs);
+
+        for (let i = 0; i < lhs.tokenCount; i++) {
+            const lr = readRange(lhs.resultBuffer, i);
+            expect(lr.selfEnd, `lhs token[${i}] selfEnd > selfStart`).toBeGreaterThan(lr.selfStart);
+            expect(i, `lhs token[${i}] >= selfStart`).toBeGreaterThanOrEqual(lr.selfStart);
+            expect(i, `lhs token[${i}] < selfEnd`).toBeLessThan(lr.selfEnd);
+            expect(lr.otherEnd, `lhs token[${i}] otherEnd >= otherStart`).toBeGreaterThanOrEqual(lr.otherStart);
+        }
+        for (let i = 0; i < rhs.tokenCount; i++) {
+            const rr = readRange(rhs.resultBuffer, i);
+            expect(rr.selfEnd, `rhs token[${i}] selfEnd > selfStart`).toBeGreaterThan(rr.selfStart);
+            expect(i, `rhs token[${i}] >= selfStart`).toBeGreaterThanOrEqual(rr.selfStart);
+            expect(i, `rhs token[${i}] < selfEnd`).toBeLessThan(rr.selfEnd);
+            expect(rr.otherEnd, `rhs token[${i}] otherEnd >= otherStart`).toBeGreaterThanOrEqual(rr.otherStart);
+        }
+    });
+});
+
+describe("plain text vs table: full pipeline", () => {
+
+    it("text content fully matches — structural-only diffs are filtered out", async () => {
+        const { diffContext } = await runFullPipeline(PLAIN_TEXT, TABLE_HTML);
+        // 텍스트가 모두 매칭되므로 구조적 토큰만의 diff는 processDiffElements에서 필터됨
+        expect(diffContext.diffs.length).toBe(0);
+    });
+
+    it("DiffEntry invariants hold", async () => {
+        const { diffContext, leftEl, rightEl } = await runFullPipeline(PLAIN_TEXT, TABLE_HTML);
+
+        for (const diff of diffContext.diffs) {
+            // leftRange references left DOM
+            expect(
+                leftEl.contains(diff.leftRange.startContainer) || diff.leftRange.startContainer === leftEl,
+                `diff[${diff.diffIndex}] leftRange in left DOM`
+            ).toBe(true);
+
+            // rightRange references right DOM
+            expect(
+                rightEl.contains(diff.rightRange.startContainer) || diff.rightRange.startContainer === rightEl,
+                `diff[${diff.diffIndex}] rightRange in right DOM`
+            ).toBe(true);
+
+            // marker exclusivity
+            expect(
+                diff.leftMarkerEl !== null && diff.rightMarkerEl !== null,
+                `diff[${diff.diffIndex}] both markers non-null`
+            ).toBe(false);
+
+            // span validity
+            expect(diff.leftSpan.end, `diff[${diff.diffIndex}] leftSpan valid`).toBeGreaterThanOrEqual(diff.leftSpan.start);
+            expect(diff.rightSpan.end, `diff[${diff.diffIndex}] rightSpan valid`).toBeGreaterThanOrEqual(diff.rightSpan.start);
+        }
+    });
+
+    it("reverse direction (table left, plain text right) also fully matches", async () => {
+        const { diffContext } = await runFullPipeline(TABLE_HTML, PLAIN_TEXT);
+        expect(diffContext.diffs.length).toBe(0);
+    });
+});

--- a/core/tests/tokenizer-edge-cases.test.ts
+++ b/core/tests/tokenizer-edge-cases.test.ts
@@ -1,0 +1,523 @@
+/**
+ * 토크나이저 엣지케이스 테스트
+ *
+ * 제외: MANUAL_ANCHOR (미구현), NO_JOIN_NEXT/NO_JOIN_PREV
+ */
+import { describe, it, expect } from "vitest";
+import { tokenize } from "../src/tokenization/tokenize";
+import {
+    TOKEN_FLAGS_HAS_FOLLOWING_SPACE,
+    TOKEN_FLAGS_HAS_PRECEDING_SPACE,
+    TOKEN_FLAGS_LINE_END,
+    TOKEN_FLAGS_LINE_START,
+    TOKEN_FLAGS_PUNCTUATION,
+    TOKEN_FLAGS_TYPE_IMAGE,
+    TOKEN_FLAGS_TYPE_STRUCTURAL,
+    TOKEN_FLAGS_TYPE_TEXT,
+    TOKEN_FLAGS_WILDCARD,
+    TOKEN_FLAGS_WORD_LIKE,
+    TOKEN_TYPE_MASK,
+    getStructuralElementType,
+    isStructuralOpen,
+    isStructuralClose,
+    STRUCTURAL_ELEMENT_TD,
+    STRUCTURAL_ELEMENT_TR,
+} from "../src/tokenization/token-flags";
+
+// ── helpers ──────────────────────────────────────────────────────
+
+function makeContainer(html: string): HTMLElement {
+    const div = document.createElement("div");
+    div.innerHTML = html;
+    return div;
+}
+
+async function tok(html: string) {
+    const container = makeContainer(html);
+    const signal = new AbortController().signal;
+    const result = await tokenize(container, signal);
+    const texts = result.tokens.map(t =>
+        result.wholeText.slice(t.textOffset, t.textOffset + t.textLength)
+    );
+    return { ...result, texts };
+}
+
+/** 텍스트 토큰만 반환 */
+function textTokens(result: Awaited<ReturnType<typeof tok>>) {
+    return result.tokens.filter(t => (t.flags & TOKEN_TYPE_MASK) === TOKEN_FLAGS_TYPE_TEXT);
+}
+
+/** 토큰의 텍스트 추출 */
+function text(result: Awaited<ReturnType<typeof tok>>, token: { textOffset: number; textLength: number }) {
+    return result.wholeText.slice(token.textOffset, token.textOffset + token.textLength);
+}
+
+// ── LINE_END / LINE_START: 블록 요소들 ─────────────────────────
+
+describe("LINE_END / LINE_START across block elements", () => {
+
+    it("<p> 사이 텍스트에 LINE_END/LINE_START", async () => {
+        const r = await tok("<p>가</p><p>나</p>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END, "가 → LINE_END").toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START, "나 → LINE_START").toBeTruthy();
+    });
+
+    it("<div> 사이 텍스트에 LINE_END/LINE_START", async () => {
+        const r = await tok("<div>가</div><div>나</div>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+
+    it("<h1>~<h6> 각각 줄 경계 생성", async () => {
+        const r = await tok("<h1>제목1</h1><h2>제목2</h2><h3>제목3</h3>");
+        const tt = textTokens(r);
+        // "제목"과 "1" 등이 별도 토큰으로 분리될 수 있음 (글자/숫자 카테고리 분리)
+        expect(tt.length).toBeGreaterThanOrEqual(3);
+        // 첫 토큰과 마지막 토큰 사이에 LINE_END/LINE_START 경계가 있어야 함
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+        expect(tt[tt.length - 1].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+    });
+
+    it("<li> 각각 줄 경계 생성", async () => {
+        const r = await tok("<ul><li>항목A</li><li>항목B</li><li>항목C</li></ul>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(3);
+        for (let i = 0; i < tt.length - 1; i++) {
+            expect(tt[i].flags & TOKEN_FLAGS_LINE_END, `tt[${i}] LINE_END`).toBeTruthy();
+            expect(tt[i + 1].flags & TOKEN_FLAGS_LINE_START, `tt[${i + 1}] LINE_START`).toBeTruthy();
+        }
+    });
+
+    it("<blockquote> 줄 경계 생성", async () => {
+        const r = await tok("앞<blockquote>인용</blockquote>뒤");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(3);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[2].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+
+    it("중첩 블록: div > p", async () => {
+        const r = await tok("<div><p>안</p><p>녕</p></div>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+});
+
+// ── LINE_END / LINE_START: BR ───────────────────────────────────
+
+describe("BR line boundary", () => {
+
+    it("BR 전후 텍스트에 LINE_END/LINE_START", async () => {
+        const r = await tok("가<br>나");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END, "가 → LINE_END").toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START, "나 → LINE_START").toBeTruthy();
+    });
+
+    it("연속 BR", async () => {
+        const r = await tok("가<br><br>나");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+
+    it("BR로 시작하는 문서", async () => {
+        const r = await tok("<br>가");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+});
+
+// ── LINE_END / LINE_START: HR (void block) ──────────────────────
+
+describe("HR (void block element)", () => {
+
+    it("HR 전후 텍스트에 LINE_END/LINE_START", async () => {
+        const r = await tok("위<hr>아래");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+});
+
+// ── LINE_END: 마지막 토큰 (구조적 토큰 뒤) ─────────────────────
+
+describe("LINE_END on last text token", () => {
+
+    it("문서 끝이 구조적 토큰이면 마지막 텍스트 토큰에 LINE_END", async () => {
+        const r = await tok("<table><tr><td>마지막</td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END, "마지막 → LINE_END").toBeTruthy();
+    });
+
+    it("여러 TD의 마지막 텍스트 토큰 모두 LINE_END", async () => {
+        const r = await tok("<table><tr><td>가</td><td>나</td><td>다</td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(3);
+        for (const t of tt) {
+            expect(t.flags & TOKEN_FLAGS_LINE_END, `"${text(r, t)}" → LINE_END`).toBeTruthy();
+        }
+    });
+
+    it("마지막 토큰이 텍스트면 LINE_END (구조적 토큰 없는 경우)", async () => {
+        const r = await tok("끝");
+        const tt = textTokens(r);
+        expect(tt[tt.length - 1].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+    });
+
+    it("중첩 테이블: 내부 테이블 마지막 텍스트 토큰에도 LINE_END", async () => {
+        const r = await tok("<table><tr><td><table><tr><td>내부</td></tr></table></td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+    });
+});
+
+// ── HAS_PRECEDING_SPACE / HAS_FOLLOWING_SPACE ───────────────────
+
+describe("HAS_PRECEDING_SPACE / HAS_FOLLOWING_SPACE", () => {
+
+    it("공백으로 구분된 단어 간 space 플래그", async () => {
+        const r = await tok("가 나");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_HAS_FOLLOWING_SPACE, "가 → HAS_FOLLOWING_SPACE").toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_HAS_PRECEDING_SPACE, "나 → HAS_PRECEDING_SPACE").toBeTruthy();
+    });
+
+    it("줄 시작 후에는 HAS_PRECEDING_SPACE 클리어", async () => {
+        const r = await tok("가<br>  나");
+        const tt = textTokens(r);
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_HAS_PRECEDING_SPACE, "줄 시작이면 HAS_PRECEDING_SPACE 없음").toBeFalsy();
+    });
+
+    it("연속 공백은 하나로 축소 (collapse)", async () => {
+        const r = await tok("가   나");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_HAS_FOLLOWING_SPACE).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_HAS_PRECEDING_SPACE).toBeTruthy();
+    });
+
+    it("공백 없이 붙은 단어에는 space 플래그 없음", async () => {
+        const r = await tok("가나");
+        const tt = textTokens(r);
+        // 같은 카테고리면 하나의 토큰
+        for (const t of tt) {
+            expect(t.flags & TOKEN_FLAGS_HAS_PRECEDING_SPACE).toBeFalsy();
+            expect(t.flags & TOKEN_FLAGS_HAS_FOLLOWING_SPACE).toBeFalsy();
+        }
+    });
+});
+
+// ── WORD_LIKE / PUNCTUATION ─────────────────────────────────────
+
+describe("WORD_LIKE and PUNCTUATION flags", () => {
+
+    it("한글 토큰은 WORD_LIKE", async () => {
+        const r = await tok("가나다");
+        const tt = textTokens(r);
+        expect(tt[0].flags & TOKEN_FLAGS_WORD_LIKE).toBeTruthy();
+    });
+
+    it("영어 토큰은 WORD_LIKE", async () => {
+        const r = await tok("hello");
+        const tt = textTokens(r);
+        expect(tt[0].flags & TOKEN_FLAGS_WORD_LIKE).toBeTruthy();
+    });
+
+    it("숫자 토큰은 WORD_LIKE", async () => {
+        const r = await tok("12345");
+        const tt = textTokens(r);
+        expect(tt[0].flags & TOKEN_FLAGS_WORD_LIKE).toBeTruthy();
+    });
+
+    it("구두점 토큰은 WORD_LIKE 아님", async () => {
+        const r = await tok("가, 나");
+        const tt = textTokens(r);
+        const comma = tt.find(t => text(r, t) === ",");
+        expect(comma, "쉼표 토큰 존재").toBeTruthy();
+        expect(comma!.flags & TOKEN_FLAGS_WORD_LIKE, "쉼표 → not WORD_LIKE").toBeFalsy();
+    });
+});
+
+// ── IMAGE 토큰 ──────────────────────────────────────────────────
+
+describe("IMAGE token", () => {
+
+    it("<img>는 TOKEN_FLAGS_TYPE_IMAGE", async () => {
+        const r = await tok('<p>앞<img src="test.png">뒤</p>');
+        const imgTokens = r.tokens.filter(t => (t.flags & TOKEN_TYPE_MASK) === TOKEN_FLAGS_TYPE_IMAGE);
+        expect(imgTokens.length).toBe(1);
+    });
+
+    it("이미지 전후 텍스트 토큰은 정상", async () => {
+        const r = await tok('<p>앞<img src="test.png">뒤</p>');
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(text(r, tt[0])).toBe("앞");
+        expect(text(r, tt[1])).toBe("뒤");
+    });
+});
+
+// ── WILDCARD 토큰 ───────────────────────────────────────────────
+
+describe("WILDCARD token", () => {
+
+    it("(추가)는 WILDCARD 플래그", async () => {
+        const r = await tok("가 (추가) 나");
+        const wt = r.tokens.filter(t => t.flags & TOKEN_FLAGS_WILDCARD);
+        expect(wt.length).toBe(1);
+        expect(text(r, wt[0])).toBe("(추가)");
+    });
+
+    it("<삭제>는 WILDCARD 플래그", async () => {
+        const r = await tok("가 <삭제> 나");
+        const wt = r.tokens.filter(t => t.flags & TOKEN_FLAGS_WILDCARD);
+        expect(wt.length).toBe(1);
+        expect(text(r, wt[0])).toBe("<삭제>");
+    });
+
+    it("[신설]는 WILDCARD 플래그", async () => {
+        const r = await tok("가 [신설] 나");
+        const wt = r.tokens.filter(t => t.flags & TOKEN_FLAGS_WILDCARD);
+        expect(wt.length).toBe(1);
+        expect(text(r, wt[0])).toBe("[신설]");
+    });
+
+    it("(현행과같음)은 WILDCARD 플래그", async () => {
+        const r = await tok("가 (현행과같음) 나");
+        const wt = r.tokens.filter(t => t.flags & TOKEN_FLAGS_WILDCARD);
+        expect(wt.length).toBe(1);
+        expect(text(r, wt[0])).toBe("(현행과같음)");
+    });
+});
+
+// ── 구조적 토큰 ─────────────────────────────────────────────────
+
+describe("structural tokens", () => {
+
+    it("TD open/close 구분", async () => {
+        const r = await tok("<table><tr><td>내용</td></tr></table>");
+        const structural = r.tokens.filter(t => t.flags & TOKEN_FLAGS_TYPE_STRUCTURAL);
+        const tdOpen = structural.filter(t => isStructuralOpen(t.flags) && getStructuralElementType(t.flags) === STRUCTURAL_ELEMENT_TD);
+        const tdClose = structural.filter(t => isStructuralClose(t.flags) && getStructuralElementType(t.flags) === STRUCTURAL_ELEMENT_TD);
+        expect(tdOpen.length).toBe(1);
+        expect(tdClose.length).toBe(1);
+    });
+
+    it("TR open/close 구분", async () => {
+        const r = await tok("<table><tr><td>내용</td></tr></table>");
+        const structural = r.tokens.filter(t => t.flags & TOKEN_FLAGS_TYPE_STRUCTURAL);
+        const trOpen = structural.filter(t => isStructuralOpen(t.flags) && getStructuralElementType(t.flags) === STRUCTURAL_ELEMENT_TR);
+        const trClose = structural.filter(t => isStructuralClose(t.flags) && getStructuralElementType(t.flags) === STRUCTURAL_ELEMENT_TR);
+        expect(trOpen.length).toBe(1);
+        expect(trClose.length).toBe(1);
+    });
+
+    it("TH는 TD와 동일한 구조적 타입", async () => {
+        const r = await tok("<table><tr><th>헤더</th></tr></table>");
+        const structural = r.tokens.filter(t => t.flags & TOKEN_FLAGS_TYPE_STRUCTURAL);
+        const thAsTd = structural.filter(t => getStructuralElementType(t.flags) === STRUCTURAL_ELEMENT_TD);
+        expect(thAsTd.length).toBe(2); // open + close
+    });
+
+    it("구조적 토큰은 lastToken을 갱신하지 않음 (wholeText 기여 없음)", async () => {
+        const r = await tok("<table><tr><td>가</td><td>나</td></tr></table>");
+        // wholeText에 구조적 토큰 텍스트가 포함되지 않음
+        expect(r.wholeText).not.toContain("\uE000");
+        expect(r.wholeText).not.toContain("\uE001");
+        // 텍스트만 포함
+        expect(r.wholeText).toContain("가");
+        expect(r.wholeText).toContain("나");
+    });
+});
+
+// ── 빈 요소 ─────────────────────────────────────────────────────
+
+describe("empty elements", () => {
+
+    it("빈 TD — 구조적 토큰만, 텍스트 토큰 없음", async () => {
+        const r = await tok("<table><tr><td></td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(0);
+        const structural = r.tokens.filter(t => t.flags & TOKEN_FLAGS_TYPE_STRUCTURAL);
+        expect(structural.length).toBeGreaterThan(0);
+    });
+
+    it("빈 TD와 채워진 TD 혼합", async () => {
+        const r = await tok("<table><tr><td></td><td>내용</td><td></td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(text(r, tt[0])).toBe("내용");
+    });
+
+    it("빈 <p>", async () => {
+        const r = await tok("<p></p><p>내용</p>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(text(r, tt[0])).toBe("내용");
+    });
+
+    it("빈 <div>", async () => {
+        const r = await tok("<div></div><div>내용</div>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+    });
+});
+
+// ── TEXTLESS 요소 ───────────────────────────────────────────────
+
+describe("TEXTLESS elements", () => {
+
+    it("UL/OL 직접 자식 텍스트 노드는 무시됨 (TEXTLESS)", async () => {
+        // jsdom은 TABLE/TR 안 텍스트를 밖으로 밀어내므로 UL로 테스트
+        const r = await tok("<ol>무시됨<li>항목</li></ol>");
+        const tt = textTokens(r);
+        const texts = tt.map(t => text(r, t));
+        expect(texts).not.toContain("무시됨");
+        expect(texts).toContain("항목");
+    });
+
+    it("UL 직접 자식 텍스트 노드는 무시됨", async () => {
+        const r = await tok("<ul>무시됨<li>항목</li></ul>");
+        const tt = textTokens(r);
+        const texts = tt.map(t => text(r, t));
+        expect(texts).not.toContain("무시됨");
+        expect(texts).toContain("항목");
+    });
+});
+
+// ── 컨테이너 (TD/TH) ───────────────────────────────────────────
+
+describe("container tracking (TD/TH)", () => {
+
+    it("각 TD는 별도의 containerIndex", async () => {
+        const r = await tok("<table><tr><td>가</td><td>나</td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].containerIndex).not.toBe(tt[1].containerIndex);
+    });
+
+    it("containers 배열에 TD 요소 포함", async () => {
+        const r = await tok("<table><tr><td>가</td><td>나</td></tr></table>");
+        // 첫 번째 container는 루트 DIV일 수 있음
+        const tdContainers = r.containers.filter(c => c.el.nodeName === "TD");
+        expect(tdContainers.length).toBeGreaterThanOrEqual(2);
+    });
+});
+
+// ── lineNumber ──────────────────────────────────────────────────
+
+describe("lineNumber tracking", () => {
+
+    it("블록 요소 사이 lineNumber 증가", async () => {
+        const r = await tok("<p>가</p><p>나</p><p>다</p>");
+        const tt = textTokens(r);
+        expect(tt[0].lineNumber).toBeLessThan(tt[1].lineNumber);
+        expect(tt[1].lineNumber).toBeLessThan(tt[2].lineNumber);
+    });
+
+    it("BR로 lineNumber 증가", async () => {
+        const r = await tok("가<br>나<br>다");
+        const tt = textTokens(r);
+        expect(tt[0].lineNumber).toBeLessThan(tt[1].lineNumber);
+        expect(tt[1].lineNumber).toBeLessThan(tt[2].lineNumber);
+    });
+
+    it("같은 줄 토큰은 같은 lineNumber", async () => {
+        const r = await tok("가 나 다");
+        const tt = textTokens(r);
+        const lineNums = new Set(tt.map(t => t.lineNumber));
+        expect(lineNums.size).toBe(1);
+    });
+
+    it("TD 사이 lineNumber 다름", async () => {
+        const r = await tok("<table><tr><td>가</td><td>나</td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt[0].lineNumber).not.toBe(tt[1].lineNumber);
+    });
+});
+
+// ── wholeText 구성 ──────────────────────────────────────────────
+
+describe("wholeText construction", () => {
+
+    it("블록 사이 개행", async () => {
+        const r = await tok("<p>가</p><p>나</p>");
+        expect(r.wholeText).toContain("가\n");
+        expect(r.wholeText).toContain("나");
+    });
+
+    it("인라인 공백은 스페이스", async () => {
+        const r = await tok("가 나");
+        expect(r.wholeText).toContain("가 나");
+    });
+
+    it("끝에 개행 포함", async () => {
+        const r = await tok("가");
+        expect(r.wholeText.endsWith("\n")).toBe(true);
+    });
+});
+
+// ── 복합 구조 ───────────────────────────────────────────────────
+
+describe("complex structures", () => {
+
+    it("테이블 안에 블록 요소", async () => {
+        const r = await tok("<table><tr><td><p>가</p><p>나</p></td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(2);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+        expect(tt[1].flags & TOKEN_FLAGS_LINE_START).toBeTruthy();
+    });
+
+    it("여러 행 테이블: 모든 셀 마지막 토큰에 LINE_END", async () => {
+        const r = await tok("<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(4);
+        for (const t of tt) {
+            expect(t.flags & TOKEN_FLAGS_LINE_END, `"${text(r, t)}" → LINE_END`).toBeTruthy();
+        }
+    });
+
+    it("colspan TD 다음 행의 다중 TD", async () => {
+        const r = await tok('<table><tr><td colspan="2">hello world</td></tr><tr><td>1.대출개요</td><td>개인택시</td></tr></table>');
+        const tt = textTokens(r);
+        // hello, world, 1., 대출개요, 개인택시
+        const allTexts = tt.map(t => text(r, t));
+        expect(allTexts).toContain("hello");
+        expect(allTexts).toContain("world");
+        expect(allTexts).toContain("대출개요");
+        expect(allTexts).toContain("개인택시");
+        // 모든 셀의 마지막 텍스트 토큰에 LINE_END
+        // "world"는 첫 TD의 마지막, "대출개요"는 두번째 TD의 마지막, "개인택시"는 세번째 TD의 마지막
+        const worldToken = tt.find(t => text(r, t) === "world");
+        const 대출개요Token = tt.find(t => text(r, t) === "대출개요");
+        const 개인택시Token = tt.find(t => text(r, t) === "개인택시");
+        expect(worldToken!.flags & TOKEN_FLAGS_LINE_END, "world → LINE_END").toBeTruthy();
+        expect(대출개요Token!.flags & TOKEN_FLAGS_LINE_END, "대출개요 → LINE_END").toBeTruthy();
+        expect(개인택시Token!.flags & TOKEN_FLAGS_LINE_END, "개인택시 → LINE_END").toBeTruthy();
+    });
+
+    it("리스트 안에 테이블", async () => {
+        const r = await tok("<ul><li><table><tr><td>셀</td></tr></table></li></ul>");
+        const tt = textTokens(r);
+        expect(tt.length).toBe(1);
+        expect(tt[0].flags & TOKEN_FLAGS_LINE_END).toBeTruthy();
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
       "integrity": "sha512-q9pE8+47bQNHb5eWVcE6oXppA+JTSwvnrhH53m0ZuHuK5MLvwsLoWrWzBTFQqQ06BVxz1gp0HblLsch8o6pvZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "picomatch": "^4.0.3"
       },
@@ -179,6 +178,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -194,6 +194,7 @@
       "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -236,6 +237,7 @@
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -253,6 +255,7 @@
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -270,6 +273,7 @@
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -280,6 +284,7 @@
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -294,6 +299,7 @@
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -332,6 +338,7 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -342,6 +349,7 @@
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -388,6 +396,7 @@
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -526,7 +535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -575,7 +583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -627,6 +634,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -644,6 +652,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -661,6 +670,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -678,6 +688,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -695,6 +706,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -712,6 +724,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -729,6 +742,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -746,6 +760,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -763,6 +778,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -780,6 +796,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -797,6 +814,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -814,6 +832,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -831,6 +850,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -848,6 +868,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -865,6 +886,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -882,6 +904,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -899,6 +922,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -916,6 +940,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -933,6 +958,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -950,6 +976,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -967,6 +994,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -984,6 +1012,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1001,6 +1030,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1018,6 +1048,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1035,6 +1066,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1052,6 +1084,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1098,6 +1131,7 @@
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1109,6 +1143,7 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1518,7 +1553,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1678,7 +1712,6 @@
       "integrity": "sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.2",
         "fflate": "^0.8.2",
@@ -1844,7 +1877,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -1862,7 +1894,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -1977,6 +2008,7 @@
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -2090,7 +2122,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2245,6 +2278,7 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2294,7 +2328,8 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
       "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
       "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2371,6 +2406,7 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2502,6 +2538,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2726,7 +2763,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.0.1",
@@ -2785,6 +2823,7 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -2798,6 +2837,7 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3125,6 +3165,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -3228,7 +3269,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3254,7 +3296,8 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3419,7 +3462,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3492,7 +3534,6 @@
       "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3567,6 +3608,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3991,6 +4033,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -4015,7 +4058,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4094,7 +4136,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -4372,7 +4413,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/zip-stream": {
       "version": "6.0.1",


### PR DESCRIPTION
## Summary
- **Tokenizer**: `LINE_END`가 구조적 토큰(`</td></tr>`) 뒤 마지막 텍스트 토큰에 설정되지 않아 `buildDiffInput`에서 buffer 텍스트가 달라지고 token ID 불일치 발생 → `lastToken` 사용으로 수정
- **Histogram diff SA**: LHS+RHS 이어붙인 배열에서 경계를 넘는 허위 LCP 매칭 발생 → sentinel ID 삽입으로 차단. parentRank 최적화 제거 (같은 ID 토큰에 다른 초기 rank 부여하는 버그)
- **테스트 추가**: loan-table-diff (7), tokenizer-edge-cases (51)

## Test plan
- [x] 전체 테스트 418개 pass
- [x] plain text `"1.대출개요 개인택시"` vs HTML table 매칭 확인
- [x] `hello world\n1.대출개요 개인택시` vs colspan 테이블 매칭 확인
- [x] 기존 diff-pipeline, run-histogram-diff, tokenizer 테스트 regression 없음

https://claude.ai/code/session_011K28kh4JcMNMvowvtznWPF
