### PR TITLE
Add GitHub Release workflow triggered by v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run pack
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: DiffSeek ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            artifacts/diffseek.html
+            artifacts/diffseek.zip
+            artifacts/base64/part-*.txt


### PR DESCRIPTION
Runs npm run pack and uploads diffseek.html, diffseek.zip, and
base64 part files to a GitHub Release.

Usage: git tag v1.0.0 && git push --tags

https://claude.ai/code/session_01TwUTeU9bdqK6nE7Pibvhqj