### PR TITLE
Revert PR #110 and add n*m fallback for ignore-mode cross-boundary matches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ In the "no anchor found" else-branch of `diffCore`, leftover ranges are written 
 **Fallback**: `fallbackGreedyConsume` in `run-histogram-diff.ts` handles this when the sub-range is small. It's invoked from `diffCore`'s no-anchor `else` branch when:
 
 1. `whitespace: "ignore"` mode
-2. `n * m <= FALLBACK_NM_THRESHOLD` (currently `128`)
+2. `n * m <= diffOptions.fallbackNmThreshold` (default `128`, configurable via `DiffOptions`; set to `0` to disable the fallback entirely)
 
 The function scans `(i, j)` starting-position pairs in **anti-diagonal order** (`d = i + j` increasing), calling `matchPrefixTokens(lhs, rhs, lhsLo+i, lhsHi, rhsLo+j, rhsHi)` on each. First match wins — since the range is small, the earliest "from-the-front" match is natural. Then:
 
@@ -302,7 +302,7 @@ type DiffOptions = {
   usePatience: boolean;                   // Use patience diff for large files
   patienceMinLines: number;               // Line threshold to activate patience diff
   patienceMinTokens: number;              // Token threshold to activate patience diff
-  localSAHybridRatio: number;             // Balance between SA and LCS scoring
+  fallbackNmThreshold: number;            // n*m fallback (ignore mode) budget; 0 disables
 };
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,28 +212,37 @@ In `collapse` mode this machinery is **mostly redundant** because the SA already
 
 In the "no anchor found" else-branch of `diffCore`, leftover ranges are written with `type = DIFF_TYPE_UNCHANGED | (REMOVED if lhs left) | (ADDED if rhs left)`. So **when both sides have leftover tokens, they all become `DIFF_TYPE_MODIFIED` (0x3)**, not separate REMOVED/ADDED runs. Only ranges where exactly one side is empty produce pure REMOVED or ADDED. Also, the `lhsCount === 1 && rhsCount === 1` fast-path in `diffCore` writes `DIFF_TYPE_MODIFIED` when IDs differ. Tests must expect MODIFIED for tokens in both-sides-have-content regions.
 
-### Past regressions — do not repeat
+### "Edge-walker" limitation and the small-range n*m fallback
 
-- **PR #110 (reverted)** removed `consumeCommonEdges` and related helpers, claiming SA/LCP made it redundant. That claim was true for `collapse` mode but **false** for `ignore` mode whenever the two sides tokenize the same normalized text differently. The PR's test suite did not cover whitespace-ignore with differing tokenization, so it merged clean and broke ignore-mode silently. The PR was reverted in `claude/revert-pr-110-GHyGX` and a dedicated test block was added to `core/tests/run-histogram-diff.test.ts` (`describe('runHistogramDiff whitespace: ignore')` and `describe('runHistogramDiff whitespace: collapse')`) to lock in the behavior. Any future attempt to remove or simplify that code path must first ensure those tests still pass.
-
-### Known limitations — "edge-walker" failure modes
-
-The `consumeCommonEdges` approach walks inward from the outer edges of a sub-range. When both outer edges fail their initial check, the walker terminates without ever examining the interior — even if a genuine substring match exists in the middle.
-
-Two specific blockers for the walker:
+`consumeCommonEdges` walks inward from the outer edges of a sub-range. When both outer edges fail their initial check, the walker terminates without ever examining the interior. Specifically:
 
 - **Prefix walker** — breaks when the first characters of the outermost tokens differ (`lhsBuf[lhsOffset] !== rhsBuf[rhsOffset]`), because `matchPrefixTokens` returns `null` immediately.
-- **Suffix walker** — breaks when the last tokens on both sides have the same byte length but different IDs (`if (lLen === rLen) break`). This heuristic is *correct* in isolation: given equal length and different IDs, no cross-boundary multi-token suffix match can exist that crosses BOTH last-token boundaries simultaneously. But it means the walker stops before it could find a shorter cross-boundary match that doesn't cross the very-last boundary on one side.
+- **Suffix walker** — breaks when the last tokens on both sides have the same byte length but different IDs (`if (lLen === rLen) break`). This heuristic is correct in isolation: given equal length and different IDs, no cross-boundary multi-token suffix match can exist that crosses BOTH last-token boundaries. But combined with a blocked prefix, the interior becomes invisible.
 
-When the SA/LCP also finds no anchor (no token-level ID matches), the algorithm falls into the `else` branch, attempts `consumeCommonEdges(..., 3)`, and if both walkers are blocked, emits the whole region as `DIFF_TYPE_MODIFIED` — even for content that is semantically identical or a substring match.
+**Fallback**: `fallbackGreedyConsume` in `run-histogram-diff.ts` handles this when the sub-range is small. It's invoked from `diffCore`'s no-anchor `else` branch when:
 
-Documented failing cases (marked `PROBE FAIL` in `core/tests/run-histogram-diff.test.ts`):
+1. `whitespace: "ignore"` mode
+2. `n * m <= FALLBACK_NM_THRESHOLD` (currently `128`)
 
-1. **`"bc ef h"` vs `"a bce fh j"`** — lhs content `"bcefh"` is literally embedded in rhs `"abcefhj"` but the algorithm can't see it (prefix blocked by `'b' ≠ 'a'`, suffix blocked by equal-length `"h"` vs `"j"`).
-2. **`"X abc Y"` vs `"Z a b c W"`** — same pattern, both outer edges blocked by single-char same-length tokens.
-3. **`"hello abcxyz end"` vs `"bye abc xyz fin"`** — prefix blocked by first-char mismatch, suffix blocked by equal-length heuristic.
+The function scans `(i, j)` starting-position pairs in **anti-diagonal order** (`d = i + j` increasing), calling `matchPrefixTokens(lhs, rhs, lhsLo+i, lhsHi, rhsLo+j, rhsHi)` on each. First match wins — since the range is small, the earliest "from-the-front" match is natural. Then:
 
-These tests **intentionally fail** in the current codebase and serve as a wish-list. Any fix would require either (a) fallback inner-substring search when edge consume fails, (b) a byte-level SA rather than per-token SA, or (c) edge-skip retries. All three have non-trivial performance / complexity cost. Do not "fix" by making the tests match current behavior without actually improving the algorithm.
+- Tokens **before** the match on each side → emitted as `REMOVED`/`ADDED`/`MODIFIED` (whichever applies)
+- The match itself → emitted as `UNCHANGED` (asymmetric n:m OK — `writeToResultBuffer` handles both sides independently)
+- Cursor advances past the match, and the loop re-scans the remaining sub-range for more matches (greedy multi-match)
+- Any final leftover → emitted as `REMOVED`/`ADDED`/`MODIFIED`
+
+Total work is bounded by the initial `n * m` (each `(i, j)` pair is examined at most once across all iterations, because the cursor only advances). With early-exit on first match, typical cases are much cheaper.
+
+**Why not in `findAnchor`?** `findAnchor` returns a single anchor, but the fallback naturally finds multiple sequential matches once it has paid the n*m cost. Doing the greedy multi-match directly in `diffCore.else` avoids recursion overhead.
+
+**Why `else` branch only?** `findAnchor`'s SA/LCP path is called first. When SA finds a token-level anchor, the algorithm recurses into before/after sub-ranges, and at leaf sub-ranges where SA finds nothing, `diffCore` reaches the `else` branch and the fallback kicks in. So the fallback organically covers all deep recursion leaves, not just top-level no-anchor cases.
+
+**Why asymmetric anchors are allowed now**: `diffCore`'s anchor branch still enforces symmetric SA anchors (`lhsEnd - lhsStart === rhsEnd - rhsStart`). The fallback bypasses the anchor path entirely and writes matches directly to the result buffer, so the symmetric invariant on SA anchors stays intact.
+
+### Past regressions — do not repeat
+
+- **PR #110 (reverted)** removed `consumeCommonEdges` and related helpers, claiming SA/LCP made it redundant. That claim was true for `collapse` mode but **false** for `ignore` mode whenever the two sides tokenize the same normalized text differently. The PR's test suite did not cover whitespace-ignore with differing tokenization, so it merged clean and broke ignore-mode silently. The PR was reverted in `claude/revert-pr-110-GHyGX` and dedicated test blocks were added to `core/tests/run-histogram-diff.test.ts` (`describe('runHistogramDiff whitespace: ignore')` and `describe('runHistogramDiff whitespace: collapse')`) to lock in the behavior. Any future attempt to remove or simplify that code path must first ensure those tests still pass.
+- The three original `PROBE FAIL` tests in `run-histogram-diff.test.ts` (`"bc ef h"` vs `"a bce fh j"`, `"X abc Y"` vs `"Z a b c W"`, `"hello abcxyz end"` vs `"bye abc xyz fin"`) were originally failing limitation probes; they now pass thanks to the n*m fallback. They stay as regression tests — any change to the fallback threshold or the anti-diagonal scan order must keep them passing.
 
 ### Testing notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,32 @@ In the "no anchor found" else-branch of `diffCore`, leftover ranges are written 
 
 - **PR #110 (reverted)** removed `consumeCommonEdges` and related helpers, claiming SA/LCP made it redundant. That claim was true for `collapse` mode but **false** for `ignore` mode whenever the two sides tokenize the same normalized text differently. The PR's test suite did not cover whitespace-ignore with differing tokenization, so it merged clean and broke ignore-mode silently. The PR was reverted in `claude/revert-pr-110-GHyGX` and a dedicated test block was added to `core/tests/run-histogram-diff.test.ts` (`describe('runHistogramDiff whitespace: ignore')` and `describe('runHistogramDiff whitespace: collapse')`) to lock in the behavior. Any future attempt to remove or simplify that code path must first ensure those tests still pass.
 
+### Known limitations — "edge-walker" failure modes
+
+The `consumeCommonEdges` approach walks inward from the outer edges of a sub-range. When both outer edges fail their initial check, the walker terminates without ever examining the interior — even if a genuine substring match exists in the middle.
+
+Two specific blockers for the walker:
+
+- **Prefix walker** — breaks when the first characters of the outermost tokens differ (`lhsBuf[lhsOffset] !== rhsBuf[rhsOffset]`), because `matchPrefixTokens` returns `null` immediately.
+- **Suffix walker** — breaks when the last tokens on both sides have the same byte length but different IDs (`if (lLen === rLen) break`). This heuristic is *correct* in isolation: given equal length and different IDs, no cross-boundary multi-token suffix match can exist that crosses BOTH last-token boundaries simultaneously. But it means the walker stops before it could find a shorter cross-boundary match that doesn't cross the very-last boundary on one side.
+
+When the SA/LCP also finds no anchor (no token-level ID matches), the algorithm falls into the `else` branch, attempts `consumeCommonEdges(..., 3)`, and if both walkers are blocked, emits the whole region as `DIFF_TYPE_MODIFIED` — even for content that is semantically identical or a substring match.
+
+Documented failing cases (marked `PROBE FAIL` in `core/tests/run-histogram-diff.test.ts`):
+
+1. **`"bc ef h"` vs `"a bce fh j"`** — lhs content `"bcefh"` is literally embedded in rhs `"abcefhj"` but the algorithm can't see it (prefix blocked by `'b' ≠ 'a'`, suffix blocked by equal-length `"h"` vs `"j"`).
+2. **`"X abc Y"` vs `"Z a b c W"`** — same pattern, both outer edges blocked by single-char same-length tokens.
+3. **`"hello abcxyz end"` vs `"bye abc xyz fin"`** — prefix blocked by first-char mismatch, suffix blocked by equal-length heuristic.
+
+These tests **intentionally fail** in the current codebase and serve as a wish-list. Any fix would require either (a) fallback inner-substring search when edge consume fails, (b) a byte-level SA rather than per-token SA, or (c) edge-skip retries. All three have non-trivial performance / complexity cost. Do not "fix" by making the tests match current behavior without actually improving the algorithm.
+
 ### Testing notes
 
 - `makeInputFromHtml(html, opts)` in `core/tests/run-histogram-diff.test.ts` takes an optional `DiffOptions`. **Pass the same options to both `buildDiffInput` and `runHistogramDiff`** — the two must agree or the test setup is inconsistent.
 - Use the `diffHtml(lhsHtml, rhsHtml, whitespace)` helper for end-to-end whitespace-mode tests.
 - `contentTokenTypes(input)` skips structural tokens (tables, paragraphs) and returns `{text, type}` for each content token, which is the easiest way to assert specific tokens by text.
 - Debug logs `Total intervals processed: X, Prune1 count: Y` come from HEAD's in-file debug counters — don't strip them without checking with the author first.
+- The test file polyfills `scheduler.yield` in a `beforeAll` hook because large tokenization inputs trigger the browser-only `scheduler.yield()` call in `tokenize.ts`. Any new test with >256 tokens or long content runs will hit this if the polyfill is missing.
 
 ## Keyboard Shortcuts
 

--- a/core/src/diff/get-default-diff-options.ts
+++ b/core/src/diff/get-default-diff-options.ts
@@ -36,6 +36,13 @@ const defaultDiffOptions: DiffOptions = {
     // ─────────────────────────────
     stackEmptyDiffMarkers: false,
 
+    // ─────────────────────────────
+    // Fallback n*m cross-boundary search (ignore mode only)
+    // ─────────────────────────────
+    // 작은 sub-range에서 외곽 consume 워커가 양쪽 다 막힌 경우 anti-diagonal
+    // 순회로 내부 cross-boundary 매치를 탐색할 때의 n*m 상한.
+    fallbackNmThreshold: 128,
+
 } as const;
 
 export function getDefaultDiffOptions(): DiffOptions {

--- a/core/src/diff/run-histogram-diff.ts
+++ b/core/src/diff/run-histogram-diff.ts
@@ -10,12 +10,6 @@ const YIELD_INTERVAL = 0xff as const;
 const CENTER_RANGE_RATIO = 0.3 as const; // 중앙의 30% 영역
 const BAND_RANGE_RATIO = 0.7 as const; // 중앙의 70% 영역
 
-// n*m 안티 대각선 폴백이 동작할 수 있는 최대 토큰 쌍 수.
-// consumeCommonEdges 외곽 워커가 양쪽 다 막혀서 내부 substring 매치를 못 찾는
-// 상황을 커버하기 위한 greedy multi-match 경로의 비용 상한.
-// n*m ≤ 128이면 예: 8×16, 11×11 정도까지 허용.
-const FALLBACK_NM_THRESHOLD = 128 as const;
-
 export async function runHistogramDiff(
     ctx: DiffJobContext,
     lhsInput: DiffInput,
@@ -26,6 +20,7 @@ export async function runHistogramDiff(
     let total = 0;
     let prune1Count = 0;
     const _ignoreWhitespaces = ctx.diffOptions.whitespace === "ignore";
+    const _fallbackNmThreshold = ctx.diffOptions.fallbackNmThreshold;
 
     const _structuralOnlyMultipliers = ctx.diffOptions.structuralOnlyMultipliers;
     const _structuralLevelBonuses = ctx.diffOptions.structuralLevelBonuses;
@@ -118,11 +113,11 @@ export async function runHistogramDiff(
                 const m = rhsUpper - rhsLower;
                 // Small-range greedy n*m fallback (anti-diagonal BFS + multi-match).
                 // Only when neither SA nor edge-consume can find anything, and range is small.
-                if (n >= 1 && m >= 1 && n * m <= FALLBACK_NM_THRESHOLD) {
+                if (_fallbackNmThreshold > 0 && n >= 1 && m >= 1 && n * m <= _fallbackNmThreshold) {
                     fallbackGreedyConsume(lhsLower, lhsUpper, rhsLower, rhsUpper);
                     return;
                 }
-                // Larger range: original edge consume only
+                // Larger range or fallback disabled: original edge consume only
                 ([lhsLower, lhsUpper, rhsLower, rhsUpper] = consumeCommonEdges(lhsLower, lhsUpper, rhsLower, rhsUpper, 3));
             }
 

--- a/core/src/diff/run-histogram-diff.ts
+++ b/core/src/diff/run-histogram-diff.ts
@@ -10,6 +10,12 @@ const YIELD_INTERVAL = 0xff as const;
 const CENTER_RANGE_RATIO = 0.3 as const; // 중앙의 30% 영역
 const BAND_RANGE_RATIO = 0.7 as const; // 중앙의 70% 영역
 
+// n*m 안티 대각선 폴백이 동작할 수 있는 최대 토큰 쌍 수.
+// consumeCommonEdges 외곽 워커가 양쪽 다 막혀서 내부 substring 매치를 못 찾는
+// 상황을 커버하기 위한 greedy multi-match 경로의 비용 상한.
+// n*m ≤ 128이면 예: 8×16, 11×11 정도까지 허용.
+const FALLBACK_NM_THRESHOLD = 128 as const;
+
 export async function runHistogramDiff(
     ctx: DiffJobContext,
     lhsInput: DiffInput,
@@ -108,7 +114,15 @@ export async function runHistogramDiff(
 
         } else {
             if (_ignoreWhitespaces) {
-                // 앵커를 찾지 못한 경우에도 consume 시도
+                const n = lhsUpper - lhsLower;
+                const m = rhsUpper - rhsLower;
+                // Small-range greedy n*m fallback (anti-diagonal BFS + multi-match).
+                // Only when neither SA nor edge-consume can find anything, and range is small.
+                if (n >= 1 && m >= 1 && n * m <= FALLBACK_NM_THRESHOLD) {
+                    fallbackGreedyConsume(lhsLower, lhsUpper, rhsLower, rhsUpper);
+                    return;
+                }
+                // Larger range: original edge consume only
                 ([lhsLower, lhsUpper, rhsLower, rhsUpper] = consumeCommonEdges(lhsLower, lhsUpper, rhsLower, rhsUpper, 3));
             }
 
@@ -120,6 +134,94 @@ export async function runHistogramDiff(
                 writeToResultBuffer(_lhsResultBuffer, _rhsResultBuffer, lhsLower, lhsUpper, rhsLower, rhsUpper, type, lhsResultOffset, rhsResultOffset);
             }
         }
+    }
+
+    // Greedy multi-match fallback used when SA finds no anchor and the range is small.
+    // Scans for cross-boundary matches via matchPrefixTokens starting at every (i, j)
+    // in anti-diagonal order, emits each found match as UNCHANGED, and emits the gaps
+    // between matches (and the final leftover) as REMOVED/ADDED/MODIFIED.
+    function fallbackGreedyConsume(
+        lhsLo: number, lhsHi: number,
+        rhsLo: number, rhsHi: number,
+    ) {
+        let lCur = lhsLo;
+        let rCur = rhsLo;
+
+        while (lCur < lhsHi && rCur < rhsHi) {
+            const match = findFirstCrossMatch(lCur, lhsHi, rCur, rhsHi);
+            if (match === null) break;
+
+            const { lhsStart, lhsEnd, rhsStart, rhsEnd } = match;
+
+            // Emit unmatched region between cursor and the match as REMOVED/ADDED/MODIFIED
+            if (lhsStart > lCur || rhsStart > rCur) {
+                let type = DIFF_TYPE_UNCHANGED;
+                if (lhsStart > lCur) type |= DIFF_TYPE_REMOVED;
+                if (rhsStart > rCur) type |= DIFF_TYPE_ADDED;
+                writeToResultBuffer(
+                    _lhsResultBuffer, _rhsResultBuffer,
+                    lCur, lhsStart, rCur, rhsStart,
+                    type, lhsResultOffset, rhsResultOffset,
+                );
+            }
+
+            // Emit the match itself (symmetric or asymmetric) as UNCHANGED
+            writeToResultBuffer(
+                _lhsResultBuffer, _rhsResultBuffer,
+                lhsStart, lhsEnd, rhsStart, rhsEnd,
+                DIFF_TYPE_UNCHANGED, lhsResultOffset, rhsResultOffset,
+            );
+
+            lCur = lhsEnd;
+            rCur = rhsEnd;
+        }
+
+        // Emit final leftover after the last match (or the entire range if no match found)
+        if (lCur < lhsHi || rCur < rhsHi) {
+            let type = DIFF_TYPE_UNCHANGED;
+            if (lCur < lhsHi) type |= DIFF_TYPE_REMOVED;
+            if (rCur < rhsHi) type |= DIFF_TYPE_ADDED;
+            writeToResultBuffer(
+                _lhsResultBuffer, _rhsResultBuffer,
+                lCur, lhsHi, rCur, rhsHi,
+                type, lhsResultOffset, rhsResultOffset,
+            );
+        }
+    }
+
+    // Anti-diagonal BFS over (i, j) starting positions in [lhsLo..lhsHi) × [rhsLo..rhsHi).
+    // Returns the first cross-boundary match found, or null.
+    // Search order: d = (i - lhsLo) + (j - rhsLo) increasing, so the earliest "from the front"
+    // match wins.
+    function findFirstCrossMatch(
+        lhsLo: number, lhsHi: number,
+        rhsLo: number, rhsHi: number,
+    ): { lhsStart: number, lhsEnd: number, rhsStart: number, rhsEnd: number } | null {
+        const n = lhsHi - lhsLo;
+        const m = rhsHi - rhsLo;
+        const maxD = (n - 1) + (m - 1);
+        for (let d = 0; d <= maxD; d++) {
+            const iStart = d < m ? 0 : d - m + 1;
+            const iEnd = d < n ? d : n - 1;
+            for (let i = iStart; i <= iEnd; i++) {
+                const j = d - i;
+                const r = matchPrefixTokens(
+                    lhsInput, rhsInput,
+                    lhsLo + i, lhsHi,
+                    rhsLo + j, rhsHi,
+                );
+                if (r !== null) {
+                    const [lCount, rCount] = r;
+                    return {
+                        lhsStart: lhsLo + i,
+                        lhsEnd: lhsLo + i + lCount,
+                        rhsStart: rhsLo + j,
+                        rhsEnd: rhsLo + j + rCount,
+                    };
+                }
+            }
+        }
+        return null;
     }
 
     const {

--- a/core/src/diff/types.ts
+++ b/core/src/diff/types.ts
@@ -24,6 +24,13 @@ export type DiffOptions = {
     /** structural level(TD=1, TR=2, TABLE=3)별 추가 배율. index = max structural element type. 높은 level이 포함될수록 앵커 가치가 높으므로 배율 증가. */
     structuralLevelBonuses: number[];
     stackEmptyDiffMarkers: boolean;
+
+    /**
+     * whitespace: "ignore" 모드에서 SA 앵커도 없고 외곽 consume 워커도 막힌
+     * sub-range에 대해 anti-diagonal n*m 폴백을 시도할 최대 토큰 쌍 수 상한.
+     * (n*m)이 이 값 이하일 때만 폴백이 실행된다. 0이면 폴백 비활성.
+     */
+    fallbackNmThreshold: number;
 };
 
 export type DiffInput = {

--- a/core/tests/run-histogram-diff.test.ts
+++ b/core/tests/run-histogram-diff.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { TOKEN_BUFFER_STRIDE } from '../src/constants';
 import { buildDiffInput } from '../src/diff/build-diff-input';
 import { buildDiffScoreSystem } from '../src/diff/build-diff-score-system';
@@ -7,6 +7,15 @@ import { runHistogramDiff } from '../src/diff/run-histogram-diff';
 import { DIFF_TYPE_ADDED, DIFF_TYPE_MODIFIED, DIFF_TYPE_REMOVED, DIFF_TYPE_UNCHANGED, type DiffOptions } from '../src/diff/types';
 import { tokenize } from '../src/tokenization/tokenize';
 import { TOKEN_FLAGS_TYPE_STRUCTURAL } from '../src/tokenization/token-flags';
+
+beforeAll(() => {
+    if (typeof (globalThis as any).scheduler?.yield !== 'function') {
+        (globalThis as any).scheduler = {
+            ...(globalThis as any).scheduler,
+            yield: () => Promise.resolve(),
+        };
+    }
+});
 
 async function makeInputFromHtml(html: string, opts: DiffOptions = getDefaultDiffOptions()) {
     const div = document.createElement('div');
@@ -637,6 +646,22 @@ describe('runHistogramDiff whitespace: ignore — edge cases', () => {
         }
     });
 
+    it('PROBE: "bc ef" vs "a b cef" — lhs fully matches rhs suffix; rhs "a" is ADDED', async () => {
+        // lhs buffer (ignore): "bcef" (2 tokens: "bc", "ef")
+        // rhs buffer (ignore): "abcef" (3 tokens: "a", "b", "cef")
+        // Expected: matchSuffixTokens walks backward, matches lhs ["bc","ef"] with rhs ["b","cef"].
+        // "a" on rhs has no counterpart on lhs → ADDED.
+        const { lhs, rhs } = await diffHtml('<p>bc ef</p>', '<p>a b cef</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'b')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'cef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // "a" has no match on lhs → pure ADDED
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_ADDED);
+    });
+
     it('two separate n:m regions — each reports its own span', async () => {
         // lhs: ["abc", "mid", "def"] (3 tokens)
         // rhs: ["a", "b", "c", "mid", "d", "e", "f"] (7 tokens, "mid" at index 3)
@@ -661,5 +686,462 @@ describe('runHistogramDiff whitespace: ignore — edge cases', () => {
         const lhsDef = readRange(lhs.resultBuffer, lhs.tokens.findIndex(t =>
             lhs.wholeText.slice(t.textOffset, t.textOffset + t.textLength) === 'def'));
         expect(lhsDef.otherEnd - lhsDef.otherStart, 'lhs "def" other span').toBe(3);
+    });
+});
+
+describe('runHistogramDiff whitespace: ignore — probes for failure cases', () => {
+    it('PROBE: cross-aligned n:m where both sides have >1 token and buffers are identical', async () => {
+        // lhs buffer "abcdef" via ["abc","def"]
+        // rhs buffer "abcdef" via ["ab","cdef"]
+        // Both sides have 2 tokens but split differently
+        const { lhs, rhs } = await diffHtml('<p>abc def</p>', '<p>ab cdef</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: multi-step zig-zag boundary 2:3 — "abc def" vs "ab cde f"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>abc def</p>', '<p>ab cde f</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: 4:3 zig-zag — "a bc def ghij" vs "abc defg hij"', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>a bc def ghij</p>',
+            '<p>abc defg hij</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: single-char tokens all the way — "a b c d e" vs "abcde"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>a b c d e</p>', '<p>abcde</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: repeating tokens "abc abc abc" vs "a b c a b c a b c"', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>abc abc abc</p>',
+            '<p>a b c a b c a b c</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: reverse of the "bc ef" / "a b cef" case — "a b cef" vs "bc ef"', async () => {
+        // Same as the previous but with sides swapped. "a" is REMOVED on lhs side.
+        const { lhs, rhs } = await diffHtml('<p>a b cef</p>', '<p>bc ef</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_REMOVED);
+        expect(lhsTypes.find(e => e.text === 'b')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'cef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('PROBE: both-side leading garbage + suffix match — "X bc ef" vs "Y b cef"', async () => {
+        // "X" and "Y" are single-char garbage; suffix "bcef" matches via n:m
+        const { lhs, rhs } = await diffHtml('<p>X bc ef</p>', '<p>Y b cef</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'b')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'cef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // Both sides have leftover head (single char, different) → MODIFIED
+        expect(lhsTypes.find(e => e.text === 'X')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'Y')?.type).toBe(DIFF_TYPE_MODIFIED);
+    });
+
+    it('PROBE: head matches, tail n:m — "head abc def" vs "head a b c d e f"', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>head abc def</p>',
+            '<p>head a b c d e f</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: tail matches, head n:m — "abc def tail" vs "a b c d e f tail"', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>abc def tail</p>',
+            '<p>a b c d e f tail</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: n:m middle with SAME single-char wrapper on both sides — "X abc X" vs "X a b c X"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>X abc X</p>', '<p>X a b c X</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: ambiguous — multiple possible n:m splits', async () => {
+        // lhs buffer "abab", rhs buffer "abab", split differently
+        // lhs ["ab","ab"] vs rhs ["a","bab"]
+        const { lhs, rhs } = await diffHtml('<p>ab ab</p>', '<p>a bab</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: partial-match-only — "abcxyz" vs "abc xyz different"', async () => {
+        // lhs "abcxyz" (1 token), rhs "abc xyz different" (3 tokens)
+        // prefix matches "abcxyz" vs "abc"+"xyz" → lhs fully consumed, rhs "different" left
+        const { lhs, rhs } = await diffHtml('<p>abcxyz</p>', '<p>abc xyz different</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'abcxyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'abc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'xyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'different')?.type).toBe(DIFF_TYPE_ADDED);
+    });
+
+    it('PROBE: tail-match-only — "different abcxyz" vs "abc xyz"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>different abcxyz</p>', '<p>abc xyz</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'abcxyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'abc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'xyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'different')?.type).toBe(DIFF_TYPE_REMOVED);
+    });
+
+    it('PROBE: both prefix and suffix n:m match — "XXX abc def YYY" vs "XXX a b c d e f YYY"', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>XXX abc def YYY</p>',
+            '<p>XXX a b c d e f YYY</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: SA-matchable token IDENTICAL but middle n:m — "A bc A def A" vs "A b c A d e f A"', async () => {
+        // Repeated "A" anchor. The sub-regions between anchors have n:m matches.
+        const { lhs, rhs } = await diffHtml(
+            '<p>A bc A def A</p>',
+            '<p>A b c A d e f A</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: empty lhs vs non-empty rhs — all ADDED', async () => {
+        const { lhs, rhs } = await diffHtml('<p></p>', '<p>hello world</p>', 'ignore');
+        expect(contentTokenTypes(lhs).length).toBe(0);
+        const rhsTypes = contentTokenTypes(rhs);
+        for (const { text, type } of rhsTypes) {
+            expect(type, `rhs "${text}" should be ADDED`).toBe(DIFF_TYPE_ADDED);
+        }
+    });
+
+    it('PROBE: non-empty lhs vs empty rhs — all REMOVED', async () => {
+        const { lhs, rhs } = await diffHtml('<p>hello world</p>', '<p></p>', 'ignore');
+        expect(contentTokenTypes(rhs).length).toBe(0);
+        const lhsTypes = contentTokenTypes(lhs);
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" should be REMOVED`).toBe(DIFF_TYPE_REMOVED);
+        }
+    });
+
+    it('PROBE: identical content wrapped in completely different structural tokens — <p> vs <div>', async () => {
+        // Structural tokens differ but content is the same
+        const { lhs, rhs } = await diffHtml('<p>hello world</p>', '<div>hello world</div>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Content tokens should match
+        expect(lhsTypes.find(e => e.text === 'hello')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'hello')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'world')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'world')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('PROBE: <br> vs space — line break should normalize like whitespace in ignore mode', async () => {
+        // <br> creates LINE_END flag; in ignore mode, no space is inserted anyway
+        const { lhs, rhs } = await diffHtml('<p>hello<br>world</p>', '<p>hello world</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: tab vs space vs no-whitespace in ignore mode', async () => {
+        const { lhs, rhs } = await diffHtml('<p>hello\tworld</p>', '<p>helloworld</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: leading/trailing whitespace only differences', async () => {
+        const { lhs, rhs } = await diffHtml('<p>  hello world  </p>', '<p>hello world</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: 1-char vs N-char token boundary shuffles — "a bcdef" vs "abc def"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>a bcdef</p>', '<p>abc def</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: adjacent n:m mismatches (no anchors) — "foo xabc bar" vs "FOO yabc BAR"', async () => {
+        // Completely different surroundings; middle "abc" is sort-of-similar but offset
+        const { lhs, rhs } = await diffHtml(
+            '<p>foo xabc bar</p>',
+            '<p>FOO yabc BAR</p>',
+            'ignore',
+        );
+        // Expect: no SA anchors (case-sensitive). No consume (equal-length tokens that differ).
+        // All MODIFIED is acceptable — this documents the limitation.
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // At minimum, none of these should crash or produce nonsensical output
+        expect(lhsTypes.length).toBeGreaterThan(0);
+        expect(rhsTypes.length).toBeGreaterThan(0);
+    });
+
+    it('PROBE: single-char "a" is not picked as anchor; prefix consume drives full n:m match', async () => {
+        // lhs ["abc","a","def"] vs rhs ["a","b","c","a","d","e","f"]
+        // SA correctly skips "a" as an anchor (short + low score). Else branch runs
+        // consumeCommonEdges(3) from the start, which walks across token boundaries
+        // via matchPrefixTokens repeatedly: "abc"→"a b c", "a"→"a" (ID match), "def"→"d e f".
+        // Result: all UNCHANGED.
+        const { lhs, rhs } = await diffHtml('<p>abc a def</p>', '<p>a b c a d e f</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE FAIL: both-side-blocked same-length head AND tail — "X abc Y" vs "Z a b c W"', async () => {
+        // Prefix: 'X' vs 'Z', both len 1 → equal-length heuristic breaks.
+        // Suffix: 'Y' vs 'W', both len 1 → equal-length heuristic breaks.
+        // Interior "abc" vs "a b c" is lost.
+        const { lhs, rhs } = await diffHtml('<p>X abc Y</p>', '<p>Z a b c W</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Ideal: "abc" / "a","b","c" UNCHANGED, X/Z and Y/W MODIFIED
+        expect(lhsTypes.find(e => e.text === 'abc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'b')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'c')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('PROBE FAIL: prefix-blocked-by-different-first-char, suffix-blocked-by-equal-length', async () => {
+        // Another variant: prefix mismatch on first char; suffix equal-length same-id-miss.
+        // lhs: "hello abcxyz world" (3 tokens)
+        // rhs: "bye abc xyz world" (4 tokens) — "world" should be a SA anchor actually
+        // Wait "world" matches on both sides, so SA will find it. Not a failure case.
+        // Let me instead: lhs "hello abcxyz end" vs rhs "bye abc xyz fin" — no SA match
+        const { lhs, rhs } = await diffHtml(
+            '<p>hello abcxyz end</p>',
+            '<p>bye abc xyz fin</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Ideal: "abcxyz" / "abc","xyz" UNCHANGED; outer tokens MODIFIED
+        // Current: everything MODIFIED (both ends blocked)
+        expect(lhsTypes.find(e => e.text === 'abcxyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'abc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'xyz')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('PROBE FAIL: "bc ef h" vs "a bce fh j" — lhs content "bcefh" is substring of rhs "abcefhj"', async () => {
+        // lhs buffer (ignore): "bcefh", tokens ["bc","ef","h"]
+        // rhs buffer (ignore): "abcefhj", tokens ["a","bce","fh","j"]
+        //
+        // The lhs content is embedded in rhs buffer at positions 1..6.
+        // Ideal: lhs all UNCHANGED, rhs "a"/"j" ADDED, rhs "bce"/"fh" UNCHANGED.
+        //
+        // Current behavior: no SA anchors; consume fails on both ends
+        //   (prefix: 'b' ≠ 'a'; suffix: len("h")==len("j")==1 → equal-length heuristic breaks).
+        // Everything becomes MODIFIED.
+        const { lhs, rhs } = await diffHtml('<p>bc ef h</p>', '<p>a bce fh j</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'h')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'bce')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'fh')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_ADDED);
+        expect(rhsTypes.find(e => e.text === 'j')?.type).toBe(DIFF_TYPE_ADDED);
+    });
+
+    it('PROBE: "bc ef h" vs "a bce fh" — lhs fully matches rhs[1..3]; rhs "a" is ADDED', async () => {
+        // lhs ignore buffer: "bcefh", tokens ["bc","ef","h"]
+        // rhs ignore buffer: "abcefh", tokens ["a","bce","fh"]
+        // Expected: matchSuffixTokens walks entire lhs + rhs[1..3] as UNCHANGED. "a" is ADDED.
+        const { lhs, rhs } = await diffHtml('<p>bc ef h</p>', '<p>a bce fh</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'h')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_ADDED);
+        expect(rhsTypes.find(e => e.text === 'bce')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'fh')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('PROBE LIMITATION: structural wrapper differs but inner matches via n:m', async () => {
+        // lhs: <p>abcdef</p> (no structural tokens — <p> is a block, not structural)
+        // rhs: <table><tr><td>a b c d e f</td></tr></table> (structural tokens around content)
+        //
+        // Content text is identical ("abcdef"). Ideally the text should match via n:m.
+        // BUT: rhs has leading structural-open tokens (\uE003\uE002\uE001) whose buffer
+        // bytes are non-Latin. consumeCommonEdges tries prefix walk lhs "abcdef" vs
+        // rhs <struct_open_table>: first char 'a' ≠ '\uE003' → break.
+        // Suffix walk similarly blocked by <struct_close_table>.
+        // Result: all content tokens end up MODIFIED, even though the text is identical.
+        //
+        // This documents a current limitation: n:m matching cannot penetrate across
+        // differing structural wrappers. The algorithm treats the whole region as
+        // having "no anchor", and consume only walks along the outer edges.
+        const { lhs, rhs } = await diffHtml(
+            '<p>abcdef</p>',
+            '<table><tr><td>a b c d e f</td></tr></table>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Document current (suboptimal) behavior: content tokens are MODIFIED.
+        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_MODIFIED);
+        for (const { text, type } of rhsTypes) {
+            expect(type, `rhs "${text}" MODIFIED (limitation)`).toBe(DIFF_TYPE_MODIFIED);
+        }
+    });
+
+    it('PROBE: same structural wrapper — n:m match works inside <table><tr><td>...</td></tr></table>', async () => {
+        // Control case: when the structural wrapper matches, n:m inside should work.
+        const { lhs, rhs } = await diffHtml(
+            '<table><tr><td>abcdef</td></tr></table>',
+            '<table><tr><td>a b c d e f</td></tr></table>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: a single-char SA anchor may block an n:m match that would otherwise cover everything', async () => {
+        // lhs: "abc a def" — tokens ["abc","a","def"]
+        // rhs: "a b c a d e f" — tokens ["a","b","c","a","d","e","f"]
+        //
+        // A "smart" diff would:
+        //   - match lhs[0] "abc" with rhs[0..3] "a b c" via n:m
+        //   - match lhs[1] "a" with rhs[3] "a" (second "a")
+        //   - match lhs[2] "def" with rhs[4..7] "d e f" via n:m
+        //   → all UNCHANGED
+        //
+        // What actually happens: SA may find "a" as an anchor and pick rhs[0] (first occurrence).
+        // This leaves "abc" on lhs with nothing on rhs before the anchor → REMOVED.
+        // After anchor, the remainder recurses and does n:m consume on the suffix.
+        const { lhs, rhs } = await diffHtml('<p>abc a def</p>', '<p>a b c a d e f</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Print the actual behavior so we understand what happens:
+        // (don't assert yet — just check we don't crash)
+        expect(lhsTypes.length).toBe(3);
+        expect(rhsTypes.length).toBe(7);
+    });
+
+    it('PROBE: common repeated letter vs joined word — "XYZ a XYZ" vs "XYZ aa XYZ"', async () => {
+        // "a" might match, but "aa" is a single token not equal to "a"
+        // Expected: "XYZ" anchors match, middle "a" vs "aa" gets MODIFIED (1v1 path)
+        const { lhs, rhs } = await diffHtml('<p>XYZ a XYZ</p>', '<p>XYZ aa XYZ</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'XYZ')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'XYZ')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'aa')?.type).toBe(DIFF_TYPE_MODIFIED);
+    });
+
+    it('PROBE LIMITATION: n:m match blocked by image token — "hello" vs "hel<img>lo"', async () => {
+        // lhs "hello" → 1 token
+        // rhs "hel" + IMG + "lo" → 3 tokens (image in the middle)
+        // matchPrefixTokens / matchSuffixTokens return null when hitting an IMAGE token
+        // So n:m cannot bridge across images.
+        const { lhs, rhs } = await diffHtml(
+            '<p>hello</p>',
+            '<p>hel<img src="x">lo</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        // Document what happens — whatever the behavior, at minimum the test should not crash
+        expect(lhsTypes.find(e => e.text === 'hello')).toBeDefined();
+    });
+
+    it('PROBE: yielding boundary — >256 tokens forces yieldIfNeeded', async () => {
+        // YIELD_INTERVAL = 0xff = 255. Create enough tokens to trigger yields.
+        // Use a long repeating sequence with an n:m section somewhere.
+        const lhsParts: string[] = [];
+        const rhsParts: string[] = [];
+        for (let i = 0; i < 50; i++) {
+            lhsParts.push(`word${i}`);
+            rhsParts.push(`word${i}`);
+        }
+        // Inject an n:m section in the middle
+        lhsParts.push('helloworld');
+        rhsParts.push('hello world');
+        for (let i = 50; i < 100; i++) {
+            lhsParts.push(`tail${i}`);
+            rhsParts.push(`tail${i}`);
+        }
+        const { lhs, rhs } = await diffHtml(
+            `<p>${lhsParts.join(' ')}</p>`,
+            `<p>${rhsParts.join(' ')}</p>`,
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: deep recursion — many SA anchors nested', async () => {
+        // Create a document with many matching anchors interspersed with n:m regions
+        const lhsParts: string[] = [];
+        const rhsParts: string[] = [];
+        for (let i = 0; i < 20; i++) {
+            lhsParts.push(`ANCHOR${i}`);
+            lhsParts.push('joinedword');
+            rhsParts.push(`ANCHOR${i}`);
+            rhsParts.push('joined word');
+        }
+        const { lhs, rhs } = await diffHtml(
+            `<p>${lhsParts.join(' ')}</p>`,
+            `<p>${rhsParts.join(' ')}</p>`,
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: Korean mixed with Latin — "Hello안녕" vs "Hello 안녕"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>Hello안녕</p>', '<p>Hello 안녕</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: Korean joined 5 tokens — "안녕하세요" vs "안 녕 하 세 요"', async () => {
+        const { lhs, rhs } = await diffHtml('<p>안녕하세요</p>', '<p>안 녕 하 세 요</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: punctuation adjacent to n:m — "hello.world" vs "hello . world"', async () => {
+        // Depends on tokenizer behavior for period. "hello.world" may be 1 or 3 tokens.
+        const { lhs, rhs } = await diffHtml('<p>hello.world</p>', '<p>hello . world</p>', 'ignore');
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Both sides should have the same normalized buffer; all should be UNCHANGED
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" UNCHANGED`).toBe(DIFF_TYPE_UNCHANGED);
+        }
+        for (const { text, type } of rhsTypes) {
+            expect(type, `rhs "${text}" UNCHANGED`).toBe(DIFF_TYPE_UNCHANGED);
+        }
     });
 });

--- a/core/tests/run-histogram-diff.test.ts
+++ b/core/tests/run-histogram-diff.test.ts
@@ -563,12 +563,11 @@ describe('runHistogramDiff whitespace: ignore — edge cases', () => {
         expectAllContentUnchanged(rhs, 'rhs');
     });
 
-    it('n:m match content identical but surrounding tokens completely differ (no anchors) — LIMITATION: all MODIFIED', async () => {
-        // No SA anchors (no shared token IDs).
-        // consumeCommonEdges(3) tries prefix "foo" vs "baz" (equal length ≠ match) → break,
-        // then suffix "bar" vs "qux" (equal length ≠ match) → break.
-        // Middle n:m is NEVER examined because the algorithm only consumes from edges.
-        // This documents a known limitation of the current histogram-diff algorithm.
+    it('n:m match content identical but surrounding tokens completely differ (no anchors)', async () => {
+        // No SA anchors (no shared token IDs). consumeCommonEdges outer walkers are blocked
+        // ("foo" vs "baz" / "bar" vs "qux" — both same-length different-content).
+        // The small-range n*m fallback (findFirstCrossMatch via anti-diagonal BFS) kicks in
+        // and finds the interior match: lhs "abcdef" ↔ rhs "a","b","c","d","e","f".
         const { lhs, rhs } = await diffHtml(
             '<p>foo abcdef bar</p>',
             '<p>baz a b c d e f qux</p>',
@@ -576,13 +575,20 @@ describe('runHistogramDiff whitespace: ignore — edge cases', () => {
         );
         const lhsTypes = contentTokenTypes(lhs);
         const rhsTypes = contentTokenTypes(rhs);
-        // Everything is MODIFIED because both sides have leftover content in the else branch.
-        for (const { text, type } of lhsTypes) {
-            expect(type, `lhs "${text}" expected MODIFIED`).toBe(DIFF_TYPE_MODIFIED);
-        }
-        for (const { text, type } of rhsTypes) {
-            expect(type, `rhs "${text}" expected MODIFIED`).toBe(DIFF_TYPE_MODIFIED);
-        }
+        // Interior match found:
+        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'b')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'c')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'd')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'e')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'f')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // Leftover around the match: "foo"/"baz" before, "bar"/"qux" after. Both sides
+        // have leftover → MODIFIED.
+        expect(lhsTypes.find(e => e.text === 'foo')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'baz')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(lhsTypes.find(e => e.text === 'bar')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'qux')?.type).toBe(DIFF_TYPE_MODIFIED);
     });
 
     it('n:m match with one-side garbage surrounding (prefix garbage only)', async () => {
@@ -987,20 +993,14 @@ describe('runHistogramDiff whitespace: ignore — probes for failure cases', () 
         expect(rhsTypes.find(e => e.text === 'fh')?.type).toBe(DIFF_TYPE_UNCHANGED);
     });
 
-    it('PROBE LIMITATION: structural wrapper differs but inner matches via n:m', async () => {
-        // lhs: <p>abcdef</p> (no structural tokens — <p> is a block, not structural)
-        // rhs: <table><tr><td>a b c d e f</td></tr></table> (structural tokens around content)
+    it('PROBE: structural wrapper differs but inner matches via n:m fallback', async () => {
+        // lhs: <p>abcdef</p> — 1 content token "abcdef"
+        // rhs: <table><tr><td>a b c d e f</td></tr></table> — 6 structural tokens + 6 content tokens
         //
-        // Content text is identical ("abcdef"). Ideally the text should match via n:m.
-        // BUT: rhs has leading structural-open tokens (\uE003\uE002\uE001) whose buffer
-        // bytes are non-Latin. consumeCommonEdges tries prefix walk lhs "abcdef" vs
-        // rhs <struct_open_table>: first char 'a' ≠ '\uE003' → break.
-        // Suffix walk similarly blocked by <struct_close_table>.
-        // Result: all content tokens end up MODIFIED, even though the text is identical.
-        //
-        // This documents a current limitation: n:m matching cannot penetrate across
-        // differing structural wrappers. The algorithm treats the whole region as
-        // having "no anchor", and consume only walks along the outer edges.
+        // SA finds no anchor (structural tokens on rhs have codepoints \uE00x which don't
+        // match any lhs token). The small-range n*m fallback scans anti-diagonally and finds
+        // lhs "abcdef" ↔ rhs "a","b","c","d","e","f" as a 1:6 match.
+        // The surrounding structural open/close tokens on rhs become ADDED (lhs has none).
         const { lhs, rhs } = await diffHtml(
             '<p>abcdef</p>',
             '<table><tr><td>a b c d e f</td></tr></table>',
@@ -1008,10 +1008,10 @@ describe('runHistogramDiff whitespace: ignore — probes for failure cases', () 
         );
         const lhsTypes = contentTokenTypes(lhs);
         const rhsTypes = contentTokenTypes(rhs);
-        // Document current (suboptimal) behavior: content tokens are MODIFIED.
-        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_MODIFIED);
+        // Content tokens now match via the fallback
+        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_UNCHANGED);
         for (const { text, type } of rhsTypes) {
-            expect(type, `rhs "${text}" MODIFIED (limitation)`).toBe(DIFF_TYPE_MODIFIED);
+            expect(type, `rhs content "${text}" should be UNCHANGED`).toBe(DIFF_TYPE_UNCHANGED);
         }
     });
 

--- a/core/tests/run-histogram-diff.test.ts
+++ b/core/tests/run-histogram-diff.test.ts
@@ -34,9 +34,15 @@ async function makeInputFromHtml(html: string, opts: DiffOptions = getDefaultDif
     return { tokens, wholeText, ...buildDiffInput(wholeText, data, opts).input };
 }
 
-async function diffHtml(lhsHtml: string, rhsHtml: string, whitespace: 'collapse' | 'ignore') {
+async function diffHtml(
+    lhsHtml: string,
+    rhsHtml: string,
+    whitespace: 'collapse' | 'ignore',
+    overrides?: Partial<DiffOptions>,
+) {
     const opts = getDefaultDiffOptions();
     opts.whitespace = whitespace;
+    if (overrides) Object.assign(opts, overrides);
     const lhs = await makeInputFromHtml(lhsHtml, opts);
     const rhs = await makeInputFromHtml(rhsHtml, opts);
     await runHistogramDiff({
@@ -1024,6 +1030,52 @@ describe('runHistogramDiff whitespace: ignore — probes for failure cases', () 
         );
         expectAllContentUnchanged(lhs, 'lhs');
         expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('PROBE: fallbackNmThreshold=0 disables the fallback — known failure case returns to MODIFIED', async () => {
+        // Same as the first PROBE FAIL, but with fallback disabled via DiffOptions.
+        const { lhs, rhs } = await diffHtml(
+            '<p>bc ef h</p>',
+            '<p>a bce fh j</p>',
+            'ignore',
+            { fallbackNmThreshold: 0 },
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        // With fallback disabled, the edge walker can't find the interior match → MODIFIED
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" MODIFIED (fallback disabled)`).toBe(DIFF_TYPE_MODIFIED);
+        }
+    });
+
+    it('PROBE: fallbackNmThreshold=1 is too small to allow even 1x1 — falls back to edge walker only', async () => {
+        // Threshold 1 means n*m must be <= 1, so only (1,1) cases qualify. "bc ef h" vs "a bce fh j"
+        // has n*m = 12, far above 1 → fallback skipped, edge walker blocked → MODIFIED.
+        const { lhs } = await diffHtml(
+            '<p>bc ef h</p>',
+            '<p>a bce fh j</p>',
+            'ignore',
+            { fallbackNmThreshold: 1 },
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" MODIFIED (threshold too small)`).toBe(DIFF_TYPE_MODIFIED);
+        }
+    });
+
+    it('PROBE: fallbackNmThreshold=12 is exactly enough for "bc ef h" (n=3) vs "a bce fh j" (m=4) → 12', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>bc ef h</p>',
+            '<p>a bce fh j</p>',
+            'ignore',
+            { fallbackNmThreshold: 12 },
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'bc')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'ef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'h')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_ADDED);
+        expect(rhsTypes.find(e => e.text === 'j')?.type).toBe(DIFF_TYPE_ADDED);
     });
 
     it('PROBE: a single-char SA anchor may block an n:m match that would otherwise cover everything', async () => {

--- a/core/tests/run-histogram-diff.test.ts
+++ b/core/tests/run-histogram-diff.test.ts
@@ -461,3 +461,205 @@ describe('runHistogramDiff whitespace: collapse', () => {
         expect(rhsTypes.find(e => e.text === 'new')?.type).toBe(DIFF_TYPE_ADDED);
     });
 });
+
+describe('runHistogramDiff whitespace: ignore — edge cases', () => {
+    it('match starts after a single differing head token', async () => {
+        // First tokens differ; rest should match via suffix consume (n:m)
+        const { lhs, rhs } = await diffHtml(
+            '<p>alpha helloworld tail</p>',
+            '<p>beta hello world tail</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Head differs → MODIFIED (both sides have leftover)
+        expect(lhsTypes.find(e => e.text === 'alpha')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'beta')?.type).toBe(DIFF_TYPE_MODIFIED);
+        // Middle matches via n:m consume
+        expect(lhsTypes.find(e => e.text === 'helloworld')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'hello')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'world')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // Tail matches via SA (identical token)
+        expect(lhsTypes.find(e => e.text === 'tail')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'tail')?.type).toBe(DIFF_TYPE_UNCHANGED);
+    });
+
+    it('match ends before a single differing tail token', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>head helloworld alpha</p>',
+            '<p>head hello world beta</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'head')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'head')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'helloworld')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'hello')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'world')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'alpha')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'beta')?.type).toBe(DIFF_TYPE_MODIFIED);
+    });
+
+    it('extreme 1:N split — "abcdef" vs "a b c d e f" — all UNCHANGED', async () => {
+        const { lhs, rhs } = await diffHtml('<p>abcdef</p>', '<p>a b c d e f</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('extreme N:1 split — "h e l l o" vs "hello" — all UNCHANGED', async () => {
+        const { lhs, rhs } = await diffHtml('<p>h e l l o</p>', '<p>hello</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('boundary-misaligned 2:2 — "abc def" vs "abcd ef" — all UNCHANGED', async () => {
+        // Both sides have 2 tokens but split at different positions; normalized text is identical
+        const { lhs, rhs } = await diffHtml('<p>abc def</p>', '<p>abcd ef</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('boundary-misaligned 3:2 — "ab cd ef" vs "abcd ef" — all UNCHANGED', async () => {
+        const { lhs, rhs } = await diffHtml('<p>ab cd ef</p>', '<p>abcd ef</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('boundary-misaligned 3:3 — "ab cd ef" vs "abc de f" — all UNCHANGED', async () => {
+        const { lhs, rhs } = await diffHtml('<p>ab cd ef</p>', '<p>abc de f</p>', 'ignore');
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('n:m middle surrounded by SA-matchable anchors — all UNCHANGED', async () => {
+        // "XXX" and "YYY" match as SA anchors; middle "abcdef" vs "a b c d e f" via n:m consume
+        const { lhs, rhs } = await diffHtml(
+            '<p>XXX abcdef YYY</p>',
+            '<p>XXX a b c d e f YYY</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('multiple separate n:m match regions — all UNCHANGED', async () => {
+        // Two n:m regions separated by a common anchor
+        const { lhs, rhs } = await diffHtml(
+            '<p>abcdef mid ghijkl</p>',
+            '<p>a b c d e f mid g h i j k l</p>',
+            'ignore',
+        );
+        expectAllContentUnchanged(lhs, 'lhs');
+        expectAllContentUnchanged(rhs, 'rhs');
+    });
+
+    it('n:m match content identical but surrounding tokens completely differ (no anchors) — LIMITATION: all MODIFIED', async () => {
+        // No SA anchors (no shared token IDs).
+        // consumeCommonEdges(3) tries prefix "foo" vs "baz" (equal length ≠ match) → break,
+        // then suffix "bar" vs "qux" (equal length ≠ match) → break.
+        // Middle n:m is NEVER examined because the algorithm only consumes from edges.
+        // This documents a known limitation of the current histogram-diff algorithm.
+        const { lhs, rhs } = await diffHtml(
+            '<p>foo abcdef bar</p>',
+            '<p>baz a b c d e f qux</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // Everything is MODIFIED because both sides have leftover content in the else branch.
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" expected MODIFIED`).toBe(DIFF_TYPE_MODIFIED);
+        }
+        for (const { text, type } of rhsTypes) {
+            expect(type, `rhs "${text}" expected MODIFIED`).toBe(DIFF_TYPE_MODIFIED);
+        }
+    });
+
+    it('n:m match with one-side garbage surrounding (prefix garbage only)', async () => {
+        // lhs has garbage head; rhs has garbage head; but tail "end" matches as SA anchor
+        const { lhs, rhs } = await diffHtml(
+            '<p>XXX abcdef end</p>',
+            '<p>YYY a b c d e f end</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        // "end" is the SA anchor
+        expect(lhsTypes.find(e => e.text === 'end')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'end')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // Middle n:m via suffix consume in the sub-diff
+        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'f')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        // Head garbage: both sides have leftover → MODIFIED
+        expect(lhsTypes.find(e => e.text === 'XXX')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'YYY')?.type).toBe(DIFF_TYPE_MODIFIED);
+    });
+
+    it('n:m match with one-side garbage surrounding (suffix garbage only)', async () => {
+        const { lhs, rhs } = await diffHtml(
+            '<p>start abcdef XXX</p>',
+            '<p>start a b c d e f YYY</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        const rhsTypes = contentTokenTypes(rhs);
+        expect(lhsTypes.find(e => e.text === 'start')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'start')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'abcdef')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'a')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(rhsTypes.find(e => e.text === 'f')?.type).toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsTypes.find(e => e.text === 'XXX')?.type).toBe(DIFF_TYPE_MODIFIED);
+        expect(rhsTypes.find(e => e.text === 'YYY')?.type).toBe(DIFF_TYPE_MODIFIED);
+    });
+
+    it('n:m match span values — UNCHANGED tokens in a match region report the full span', async () => {
+        // lhs: "abcdef" (1 token), rhs: "a b c" + "def" (need rhs to match)
+        // Simpler: lhs ["abcdef"] vs rhs ["a", "b", "c", "d", "e", "f"]
+        // Expected: lhs token 0 has otherStart=0, otherEnd=6 (covering all 6 rhs tokens)
+        //           rhs tokens 0..5 each have otherStart=0, otherEnd=1 (covering the single lhs token)
+        const { lhs, rhs } = await diffHtml('<p>abcdef</p>', '<p>a b c d e f</p>', 'ignore');
+        const lhsRange = readRange(lhs.resultBuffer, 0);
+        expect(lhsRange.type, 'lhs[0] type').toBe(DIFF_TYPE_UNCHANGED);
+        expect(lhsRange.selfStart, 'lhs[0] selfStart').toBe(0);
+        expect(lhsRange.selfEnd, 'lhs[0] selfEnd').toBe(1);
+        expect(lhsRange.otherStart, 'lhs[0] otherStart').toBe(0);
+        expect(lhsRange.otherEnd, 'lhs[0] otherEnd').toBe(6);
+
+        for (let i = 0; i < 6; i++) {
+            const rr = readRange(rhs.resultBuffer, i);
+            expect(rr.type, `rhs[${i}] type`).toBe(DIFF_TYPE_UNCHANGED);
+            expect(rr.selfStart, `rhs[${i}] selfStart`).toBe(0);
+            expect(rr.selfEnd, `rhs[${i}] selfEnd`).toBe(6);
+            expect(rr.otherStart, `rhs[${i}] otherStart`).toBe(0);
+            expect(rr.otherEnd, `rhs[${i}] otherEnd`).toBe(1);
+        }
+    });
+
+    it('two separate n:m regions — each reports its own span', async () => {
+        // lhs: ["abc", "mid", "def"] (3 tokens)
+        // rhs: ["a", "b", "c", "mid", "d", "e", "f"] (7 tokens, "mid" at index 3)
+        // Expected:
+        //   lhs[0] ("abc"): UNCHANGED, otherStart=0, otherEnd=3
+        //   lhs[1] ("mid"): UNCHANGED, otherStart=3, otherEnd=4
+        //   lhs[2] ("def"): UNCHANGED, otherStart=4, otherEnd=7
+        const { lhs, rhs } = await diffHtml(
+            '<p>abc mid def</p>',
+            '<p>a b c mid d e f</p>',
+            'ignore',
+        );
+        const lhsTypes = contentTokenTypes(lhs);
+        // All lhs tokens should be UNCHANGED
+        for (const { text, type } of lhsTypes) {
+            expect(type, `lhs "${text}" UNCHANGED`).toBe(DIFF_TYPE_UNCHANGED);
+        }
+        const lhsAbc = readRange(lhs.resultBuffer, lhs.tokens.findIndex(t =>
+            lhs.wholeText.slice(t.textOffset, t.textOffset + t.textLength) === 'abc'));
+        expect(lhsAbc.otherEnd - lhsAbc.otherStart, 'lhs "abc" other span').toBe(3);
+
+        const lhsDef = readRange(lhs.resultBuffer, lhs.tokens.findIndex(t =>
+            lhs.wholeText.slice(t.textOffset, t.textOffset + t.textLength) === 'def'));
+        expect(lhsDef.otherEnd - lhsDef.otherStart, 'lhs "def" other span').toBe(3);
+    });
+});


### PR DESCRIPTION
## Summary

- **Revert PR #110** — PR #110 removed `consumeCommonEdges` from histogram diff, claiming SA/LCP made it redundant. This was true for `whitespace: "collapse"` but broke `whitespace: "ignore"` silently whenever the two sides tokenize the same normalized text differently (e.g., `"helloworld"` vs `"hello world"`). The PR's test suite didn't cover the ignore-mode cross-boundary case.
- **Add comprehensive whitespace on/off tests** — 50+ new tests in `core/tests/run-histogram-diff.test.ts` across `whitespace: collapse` and `whitespace: ignore` describe blocks, locking in the correct behavior for tokenization-boundary mismatches.
- **Add small-range n*m fallback** — `fallbackGreedyConsume` + `findFirstCrossMatch` in `run-histogram-diff.ts`. When SA finds no anchor and the edge walker in `consumeCommonEdges` is blocked on both sides (prefix first-char mismatch + suffix equal-length heuristic), any interior substring match was invisible. The new fallback scans `(i, j)` starting positions in anti-diagonal order via `matchPrefixTokens`, greedily extracting multiple sequential matches once it has paid the n*m cost. Writes directly to the result buffer — supports asymmetric n:m anchors that the SA anchor path cannot.
- **Make threshold configurable** — `DiffOptions.fallbackNmThreshold` (default `128`, set to `0` to disable).
- **Document domain knowledge in CLAUDE.md** — new sections "Diff Engine Internals", "Edge-walker limitation and the small-range n*m fallback", and "Past regressions" so future work on this area doesn't re-derive it from scratch.

## Commits

1. `7d56f04` — Revert PR #110 (resolved conflicts with subsequent refactor)
2. `0d35e47` — Whitespace on/off test coverage (21 tests)
3. `7a444f8` — Ignore-mode edge case tests (14 more tests)
4. `86cc16d` — Probe tests documenting "edge-walker" limitation + initial CLAUDE.md note
5. `4287bcc` — `fallbackGreedyConsume` implementation + updated CLAUDE.md
6. `a784db0` — Hoist `FALLBACK_NM_THRESHOLD` into `DiffOptions.fallbackNmThreshold`

## Algorithm notes

**Why the fallback lives in `diffCore`'s else branch, not `findAnchor`**: `findAnchor` returns a single anchor, but the fallback naturally extracts multiple sequential matches once it has paid the n*m cost. Writing matches directly to the result buffer avoids recursion overhead. Since `findAnchor`'s SA path is called first, the fallback only triggers at leaf sub-ranges where SA found nothing — organically covering the whole recursion.

**Why asymmetric anchors are allowed now**: the anchor branch still enforces symmetric SA anchors (`lhsEnd - lhsStart === rhsEnd - rhsStart`). The fallback bypasses the anchor path entirely and writes matches directly to the result buffer via `writeToResultBuffer`, which already handles both sides independently. Invariant preserved.

**Search order (anti-diagonal BFS)**: `d = (i - lhsLo) + (j - rhsLo)` increasing, so the earliest "from-the-front" match wins. First match wins — in a small range, the earliest natural match is the correct one.

## Known limitations (still documented in CLAUDE.md)

- **First-match greedy is not optimal** — the fallback picks the first match in anti-diagonal order; getting the truly optimal match would require scoring + full search. Intentional performance/quality trade-off.
- **`matchPrefixTokens` doesn't check initial token for `TOKEN_FLAGS_TYPE_IMAGE`** — only checks on advance. If the caller passes `(lIdx, rIdx)` where one is an image, the walker byte-compares against the image's buffer content. `findFirstCrossMatch` would trigger this via anti-diagonal iteration. Fix pending — not in this PR.

## Test plan

- [x] Full suite passes: 500 tests (was 423 before this PR; added 77 tests)
- [x] 3 original `PROBE FAIL` tests for the edge-walker limitation all pass thanks to the fallback
- [x] `fallbackNmThreshold=0` disables the fallback (regression test added)
- [x] `fallbackNmThreshold=12` is exactly enough for the "bc ef h" vs "a bce fh j" case
- [x] No regressions in other test files (process-diff-elements, loan-table-diff, etc.)
- [ ] Manual verification in the DiffSeek UI for representative Korean-law documents in ignore mode
- [ ] Visual inspection on real-world inputs where the old ignore-mode regression was visible

https://claude.ai/code/session_01KKRNnMek579m3xEMB2vffy