### PR TITLE
Guard alignAnchors against invalid measurements and non-monotonic Y

### DIFF
--- a/core/src/engine/align-anchors.ts
+++ b/core/src/engine/align-anchors.ts
@@ -62,9 +62,9 @@ export async function alignAnchors({
 			//  잘못된 delta를 계산하고 양쪽에 발산하는 거대 패딩을 유발함)
 			if (
 				!pair.leftEl.isConnected ||
-				(pair.leftEl as HTMLElement).offsetParent === null ||
+				pair.leftEl.offsetParent === null ||
 				!pair.rightEl.isConnected ||
-				(pair.rightEl as HTMLElement).offsetParent === null
+				pair.rightEl.offsetParent === null
 			) {
 				numSkipped++;
 				continue;

--- a/core/src/engine/align-anchors.ts
+++ b/core/src/engine/align-anchors.ts
@@ -45,14 +45,53 @@ export async function alignAnchors({
 	let numSkipped = 0;
 	let adjustedAboveViewportBottom = false;
 
+	// 단조성 방어: 이전 pair보다 앞선 Y로 측정되면 역전 → 적용 시 발산 가능.
+	// run 전체에 걸쳐 단조 증가여야 함.
+	let prevLeftY = Number.NEGATIVE_INFINITY;
+	let prevRightY = Number.NEGATIVE_INFINITY;
+
 	for (let batchStart = 0; batchStart < anchorPairs.length; batchStart += BATCH_SIZE) {
 		const batchEnd = Math.min(batchStart + BATCH_SIZE, anchorPairs.length);
 		const batchSize = batchEnd - batchStart;
 
 		for (let j = 0; j < batchSize; j++) {
 			const pair = anchorPairs[batchStart + j];
+
+			// 측정 가능성 확인: DOM에 연결되어 있고 레이아웃에 포함되어야 함
+			// (조상이 display:none이면 offsetParent === null, gBCR은 0을 반환하여
+			//  잘못된 delta를 계산하고 양쪽에 발산하는 거대 패딩을 유발함)
+			if (
+				!pair.leftEl.isConnected ||
+				(pair.leftEl as HTMLElement).offsetParent === null ||
+				!pair.rightEl.isConnected ||
+				(pair.rightEl as HTMLElement).offsetParent === null
+			) {
+				numSkipped++;
+				continue;
+			}
+
 			const leftY = pair.leftEl.getBoundingClientRect().y + leftScrollTop - leftEditorTop;
 			const rightY = pair.rightEl.getBoundingClientRect().y + rightScrollTop - rightEditorTop;
+
+			// 비단조 방어: 어느 한쪽이라도 이전 pair보다 위면 적용하지 않음.
+			// 정상 흐름에서는 diff 단조성으로 인해 발생하지 않지만,
+			// 발생하면 다음 pair 적용이 이전 pair에 역피드백되어 발산함.
+			if (leftY < prevLeftY || rightY < prevRightY) {
+				if (import.meta.env.DEV) {
+					console.warn("[alignAnchors] non-monotonic anchor pair, skipping", {
+						index: batchStart + j,
+						leftY,
+						rightY,
+						prevLeftY,
+						prevRightY,
+					});
+				}
+				numSkipped++;
+				continue;
+			}
+			prevLeftY = leftY;
+			prevRightY = rightY;
+
 			// delta = 패딩 적용 전 두 앵커의 Y 위치 차이.
 			// gBCR.y는 ::before 패딩에 영향받지 않는 요소 top을 반환하므로
 			// 별도 보정 없이 leftY - rightY가 패딩 전 위치 차이가 됨.

--- a/core/tests/align-anchors.test.ts
+++ b/core/tests/align-anchors.test.ts
@@ -40,6 +40,10 @@ function mockGBCR(el: HTMLElement, y: number) {
 		bottom: y + 20,
 		toJSON() {},
 	});
+	// alignAnchors의 가시성 가드(isConnected + offsetParent)를 통과시키기 위해
+	// jsdom에서 둘 다 truthy하게 강제. 실제 브라우저 레이아웃과 무관.
+	Object.defineProperty(el, "isConnected", { value: true, configurable: true });
+	Object.defineProperty(el, "offsetParent", { value: document.body, configurable: true });
 }
 
 /**
@@ -350,5 +354,135 @@ describe("alignAnchors — 패딩 방향 전환", () => {
 		expect(rightEl.style.getPropertyValue("--ds-adjust")).toBe("50px");
 		expect(leftEl.classList.contains("ds-padded")).toBe(false);
 		expect(leftEl.style.getPropertyValue("--ds-adjust")).toBe("");
+	});
+});
+
+// ══════════════════════════════════════════════════════════════════
+
+describe("alignAnchors — 방어 가드", () => {
+	it("leftEl이 DOM에서 분리되어 있으면 skip (적용 안 함)", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		const leftEl = makeDsAnchor();
+		const rightEl = makeDsAnchor();
+		mockGBCR(leftEl, 100);
+		mockGBCR(rightEl, 200);
+		// left만 분리된 상태로 override
+		Object.defineProperty(leftEl, "isConnected", { value: false, configurable: true });
+
+		const pair = createAnchorPair(leftEl, rightEl, 0, markerElements);
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		// 측정 불가 → skip. delta/패딩 변화 없음.
+		expect(pair.delta).toBe(0);
+		expect(leftEl.classList.contains("ds-padded")).toBe(false);
+		expect(rightEl.classList.contains("ds-padded")).toBe(false);
+	});
+
+	it("offsetParent이 null인 요소(display:none 조상)는 skip", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		const leftEl = makeDsAnchor();
+		const rightEl = makeDsAnchor();
+		mockGBCR(leftEl, 100);
+		mockGBCR(rightEl, 200);
+		// right가 display:none 조상 아래로 숨겨진 상황
+		Object.defineProperty(rightEl, "offsetParent", { value: null, configurable: true });
+
+		const pair = createAnchorPair(leftEl, rightEl, 0, markerElements);
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		// 측정 불가 → skip.
+		expect(pair.delta).toBe(0);
+		expect(leftEl.classList.contains("ds-padded")).toBe(false);
+		expect(rightEl.classList.contains("ds-padded")).toBe(false);
+	});
+
+	it("앵커 Y 순서가 비단조이면 해당 pair를 skip (발산 방지)", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		// pair1: left=100, right=500 (양쪽 정상)
+		// pair2: left=300, right=200 → right가 pair1.right(500)보다 작음 = 역전
+		// 적용하면 피드백으로 발산하므로 skip해야 함.
+		const l1 = makeDsAnchor();
+		const r1 = makeDsAnchor();
+		mockGBCR(l1, 100);
+		mockGBCR(r1, 500);
+		const pair1 = createAnchorPair(l1, r1, 0, markerElements, 0);
+
+		const l2 = makeDsAnchor();
+		const r2 = makeDsAnchor();
+		mockGBCR(l2, 300);
+		mockGBCR(r2, 200); // right 역전
+		const pair2 = createAnchorPair(l2, r2, 0, markerElements, 1);
+
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair1, pair2],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		// pair1은 정상 적용 (delta = 100-500 = -400)
+		expect(pair1.delta).toBe(-400);
+		expect(l1.classList.contains("ds-padded")).toBe(true);
+		// pair2는 비단조라 skip → 패딩 없음, delta 유지
+		expect(pair2.delta).toBe(0);
+		expect(l2.classList.contains("ds-padded")).toBe(false);
+		expect(r2.classList.contains("ds-padded")).toBe(false);
+	});
+
+	it("left-Y 역전만 있어도 skip", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		const l1 = makeDsAnchor();
+		const r1 = makeDsAnchor();
+		mockGBCR(l1, 300);
+		mockGBCR(r1, 100);
+		const pair1 = createAnchorPair(l1, r1, 0, markerElements, 0);
+
+		const l2 = makeDsAnchor();
+		const r2 = makeDsAnchor();
+		mockGBCR(l2, 200); // left 역전 (pair1.left=300보다 앞)
+		mockGBCR(r2, 400);
+		const pair2 = createAnchorPair(l2, r2, 0, markerElements, 1);
+
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair1, pair2],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		expect(pair1.delta).toBe(200); // 300-100
+		expect(pair2.delta).toBe(0); // skip
+		expect(l2.classList.contains("ds-padded")).toBe(false);
+		expect(r2.classList.contains("ds-padded")).toBe(false);
 	});
 });


### PR DESCRIPTION
alignAnchors could produce divergent, screen-filling padding when anchor
element measurements were invalid or when pair Y order was effectively
reversed between left and right editors.

Invalid measurement path: a ds-anchor (default display:none) or a
borrowed block whose ancestor is display:none returns getBoundingClientRect
as all-zeros. The resulting delta was then huge in one direction and got
applied as padding.

Non-monotonic path: when pair_i is above pair_j on the left but below
pair_j on the right, applying padding to pair_i pushes pair_j's opposite
side further away, which in turn increases pair_j's delta, which pushes
pair_i's opposite side further, etc. Each iteration roughly multiplies
the delta, producing screen-sized padding within a few frames.

Two defensive guards added to the align loop:

1. Visibility/connectivity check: skip pairs where either element is
   disconnected or has null offsetParent. Measurement cannot be trusted
   for these and any delta derived from them is spurious.

2. Monotonicity check: track the previous pair's leftY/rightY within a
   run; skip any pair whose Y goes backwards on either side. Normal diff
   algorithm monotonicity guarantees this never happens; if it does,
   applying the delta would feed back into the previous pair and diverge.

Tests in core/tests/align-anchors.test.ts now attach mocked isConnected
and offsetParent on anchor elements so existing tests still exercise the
apply path, and four new tests cover the disconnected / display:none /
reversed-right-Y / reversed-left-Y skip paths.

https://claude.ai/code/session_01ABh5V12j5MPRP5ZLb3sUyB