### PR TITLE
Fix anchor alignment: both-padding defense, XOR monotonicity, and mutation cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,8 @@ Test results are written to `test-results.json`. Tests use a jsdom environment t
 | ------------------------------------------- | -------------------------------------------------------------------------------- |
 | `core/src/engine/diffseek-engine.ts`        | Central orchestrator; manages editors, diff pipeline, events, keyboard shortcuts |
 | `core/src/engine/diff-pipeline.ts`          | Coordinates tokenize → diff → render workflow                                    |
-| `core/src/engine/anchor-manager.ts`         | Identifies matching line pairs for sync mode alignment                           |
+| `core/src/engine/process-diff-elements.ts`  | Builds DOM anchor pairs (`<DS-ANCHOR>`/`<DS-DIFF>`) from diff output for sync mode |
+| `core/src/engine/align-anchors.ts`          | Aligns anchor pairs in sync mode via `::before` padding injection                |
 | `core/src/diff/run-histogram-diff.ts`       | Primary diff algorithm (histogram-based)                                         |
 | `core/src/diff/patience-diff.ts`            | Fallback diff for large files                                                    |
 | `core/src/diff/get-default-diff-options.ts` | Default `DiffOptions` values                                                     |

--- a/core/src/editor/editor.ts
+++ b/core/src/editor/editor.ts
@@ -1,4 +1,4 @@
-import { ABORT_REASON_CANCELLED, BLOCK_ELEMENTS, MANUAL_ANCHOR_TAG_NAME } from "../constants";
+import { ABORT_REASON_CANCELLED, ANCHOR_TAG_NAME, BLOCK_ELEMENTS, DIFF_TAG_NAME, MANUAL_ANCHOR_TAG_NAME } from "../constants";
 import { sanitizeHTML } from "../sanitize/sanitize";
 import type { ContainerInfo, LineBoundaryInfo, Token, TokenizerOptions } from "../tokenization";
 import { tokenize } from "../tokenization/tokenize";
@@ -18,6 +18,34 @@ import { paragraphizePlainText } from "./paragraphize-plain-text";
 import type { EditorContext, EditorName, EditorOptions, SavedScrollRef } from "./types";
 
 const MAX_LENGTH_FOR_EXECCOMMAND_PASTE = 200_000 as const;
+
+/**
+ * MutationObserver가 새로 추가된 노드에서 "브라우저가 줄 분할 시 복사해버린"
+ * 마커 잔여 attr(data-anchor-index / data-diff-index + 패딩)을 제거한다.
+ *
+ * ⚠️ 엔진이 직접 삽입하는 앵커/마커 요소(DS-ANCHOR / DS-DIFF)는 건드리면 안 된다.
+ * 이들은 삽입 직후 `activateAnchorEl`이 동기적으로 data-anchor-index를 설정하는데,
+ * MutationObserver 콜백은 그 이후(다음 microtask)에 실행되므로, 필터가 없으면
+ * 방금 삽입한 정상 앵커의 index/패딩까지 지워버린다. 그 결과:
+ *   - 새로 삽입된 앵커가 `[data-anchor-index]` 셀렉터에서 빠져 sync mode에서 display:none
+ *     → alignAnchors 가시성 가드에 걸려 skip → 정렬 누락
+ *   - 좌우가 재사용/신규 삽입 비율이 달라 DOM의 앵커 index가 어긋나 보임
+ *     (예: 왼쪽 1,2,3… / 오른쪽 0,1,2…)
+ * 이 요소들은 markerElements / cleanupUnusedMarkers로 별도 관리되므로 여기서 제외한다.
+ *
+ * @internal — exported for testing only
+ */
+export function cleanCopiedAnchorAttrs(node: Node): void {
+	if (node.nodeType !== Node.ELEMENT_NODE) return;
+	const el = node as HTMLElement;
+	// 엔진이 관리하는 앵커/마커는 제외 (브라우저 복사 대상이 아님)
+	if (el.nodeName === ANCHOR_TAG_NAME || el.nodeName === DIFF_TAG_NAME) return;
+	if (el.dataset.anchorIndex === undefined) return;
+	el.classList.remove("ds-padded", "ds-striped");
+	el.style.removeProperty("--ds-adjust");
+	delete el.dataset.anchorIndex;
+	delete el.dataset.diffIndex;
+}
 const TOKENIZE_DEBOUNCE_DELAY_MS = 200 as const;
 
 export type EditorCallbacks = {
@@ -383,15 +411,7 @@ export class Editor implements EditorContext {
 		// TODO: editor가 이 앵커의 세부 attr까지 알고 있는 건 느낌이 좋지 않다.
 		for (const mutation of mutations) {
 			for (const node of mutation.addedNodes) {
-				if (node.nodeType === Node.ELEMENT_NODE) {
-					const el = node as HTMLElement;
-					if (el.dataset.anchorIndex !== undefined) {
-						el.classList.remove("ds-padded", "ds-striped");
-						el.style.removeProperty("--ds-adjust");
-						delete el.dataset.anchorIndex;
-						delete el.dataset.diffIndex;
-					}
-				}
+				cleanCopiedAnchorAttrs(node);
 			}
 		}
 	}

--- a/core/src/engine/align-anchors.ts
+++ b/core/src/engine/align-anchors.ts
@@ -57,6 +57,17 @@ export async function alignAnchors({
 		for (let j = 0; j < batchSize; j++) {
 			const pair = anchorPairs[batchStart + j];
 
+			// 양쪽 패딩 불변식 방어(both-padding):
+			// 한 pair는 항상 "더 아래에 있는 한쪽"에만 패딩이 붙어야 한다. 양쪽에
+			// ds-padded가 동시에 남아있는 것은 불가능한 상태다(서로 다른 이전 pair의
+			// 패딩을 각각 물려받았고, 이 pair가 skip되어 정리되지 않은 경우 발생).
+			// 측정 전에 둘 다 제거하고 delta를 리셋해 아래 로직이 한쪽에만 재적용하도록 한다.
+			if (pair.leftEl.classList.contains("ds-padded") && pair.rightEl.classList.contains("ds-padded")) {
+				clearPadding(pair.leftEl, markerElements);
+				clearPadding(pair.rightEl, markerElements);
+				pair.delta = 0;
+			}
+
 			// 측정 가능성 확인: DOM에 연결되어 있고 레이아웃에 포함되어야 함
 			// (조상이 display:none이면 offsetParent === null, gBCR은 0을 반환하여
 			//  잘못된 delta를 계산하고 양쪽에 발산하는 거대 패딩을 유발함)
@@ -253,6 +264,14 @@ function diagnoseResidual(anchorPairs: readonly AnchorPair[], leftEditor: Editor
 	}
 }
 
+/** 요소에서 정렬 패딩 상태(클래스/CSS 변수/장부)를 모두 제거한다. */
+function clearPadding(el: HTMLElement, markerElements: MarkerElementsMap) {
+	el.classList.remove("ds-padded", "ds-striped");
+	el.style.removeProperty("--ds-adjust");
+	const info = markerElements.get(el);
+	if (info) info.adjust = 0;
+}
+
 function applyDeltaToPair(pair: AnchorPair, delta: number, markerElements: MarkerElementsMap) {
 	let theEl: HTMLElement;
 	let otherEl: HTMLElement;
@@ -266,10 +285,7 @@ function applyDeltaToPair(pair: AnchorPair, delta: number, markerElements: Marke
 		otherEl = pair.rightEl;
 	}
 	// 반대쪽 이전 패딩 제거
-	otherEl.classList.remove("ds-padded", "ds-striped");
-	otherEl.style.removeProperty("--ds-adjust");
-	const otherInfo = markerElements.get(otherEl);
-	if (otherInfo) otherInfo.adjust = 0;
+	clearPadding(otherEl, markerElements);
 
 	// 적용
 	theEl.style.setProperty("--ds-adjust", `${delta}px`);

--- a/core/src/engine/align-anchors.ts
+++ b/core/src/engine/align-anchors.ts
@@ -73,12 +73,16 @@ export async function alignAnchors({
 			const leftY = pair.leftEl.getBoundingClientRect().y + leftScrollTop - leftEditorTop;
 			const rightY = pair.rightEl.getBoundingClientRect().y + rightScrollTop - rightEditorTop;
 
-			// 비단조 방어: 어느 한쪽이라도 이전 pair보다 위면 적용하지 않음.
-			// 정상 흐름에서는 diff 단조성으로 인해 발생하지 않지만,
-			// 발생하면 다음 pair 적용이 이전 pair에 역피드백되어 발산함.
-			if (leftY < prevLeftY || rightY < prevRightY) {
+			// 비단조 방어: 발산을 유발하는 것은 "교차 역전"뿐이다.
+			// (e0e8e38의 실제 원인: pair가 left에서는 이전보다 아래인데 right에서는 위 —
+			//  즉 한쪽만 역행. 이때 적용 delta가 이전 pair로 역피드백되어 프레임마다 배가됨.)
+			// 반대로 "양쪽이 함께 역행"하는 경우는 표 셀/다단에서 새 열(column)이
+			// 시작될 때 정상적으로 발생하는 좌표 리셋이므로 적법 → 허용하고 baseline을 갱신.
+			const leftBack = leftY < prevLeftY;
+			const rightBack = rightY < prevRightY;
+			if (leftBack !== rightBack) {
 				if (import.meta.env.DEV) {
-					console.warn("[alignAnchors] non-monotonic anchor pair, skipping", {
+					console.warn("[alignAnchors] cross-side non-monotonic anchor pair, skipping", {
 						index: batchStart + j,
 						leftY,
 						rightY,
@@ -219,8 +223,9 @@ function diagnoseResidual(anchorPairs: readonly AnchorPair[], leftEditor: Editor
 		const rightY = p.rightEl.getBoundingClientRect().y + rightScrollTop - rightTop;
 		const residual = Math.round(leftY - rightY);
 
-		const nonMonotonic = leftY < prevLeftY || rightY < prevRightY;
-		if (!nonMonotonic) {
+		// 실제 가드와 동일한 XOR 판정: 한쪽만 역행하는 교차 역전만 skip 대상.
+		const crossInverted = leftY < prevLeftY !== rightY < prevRightY;
+		if (!crossInverted) {
 			prevLeftY = leftY;
 			prevRightY = rightY;
 		}
@@ -230,7 +235,7 @@ function diagnoseResidual(anchorPairs: readonly AnchorPair[], leftEditor: Editor
 				index: i,
 				residual,
 				delta: p.delta,
-				reason: nonMonotonic ? "non-monotonic(skip)" : "processed-but-off",
+				reason: crossInverted ? "cross-inverted(skip)" : "processed-but-off",
 				diffIndex: p.diffIndex,
 				left: p.leftEl.nodeName,
 				right: p.rightEl.nodeName,

--- a/core/src/engine/align-anchors.ts
+++ b/core/src/engine/align-anchors.ts
@@ -177,6 +177,74 @@ export async function alignAnchors({
 		console.debug(
 			`Aligned ${anchorPairs.length} anchor pairs in ${performance.now() - startTime}ms (${numFrames} frames)`,
 		);
+		diagnoseResidual(anchorPairs, leftEditor, rightEditor);
+	}
+}
+
+/**
+ * [DEV 진단] 정렬 패스가 끝난 뒤 각 pair를 다시 측정해 1px를 초과해 남은
+ * 잔차(residual)를 보고한다. "누적"이 아니라 이산적으로 어긋난 pair를 찾기 위한 것.
+ *
+ * 각 offender에 대해:
+ *   - residual: 정렬 후 실제 leftY-rightY (0에 가까워야 정상)
+ *   - delta:    pair가 마지막으로 기록한 적용값
+ *   - reason:   왜 어긋났는지 추정 (skip 여부/원인 분류)
+ *   - left/right: 앵커 요소 태그 (DS-ANCHOR=별도 마커, 그 외=borrow된 블록)
+ *   - pad:      실제 CSS --ds-adjust
+ * 브라우저 콘솔에서 이 표를 보면 원인이 (a)skip (b)무앵커 (c)무효패딩 중 무엇인지 판별 가능.
+ */
+function diagnoseResidual(anchorPairs: readonly AnchorPair[], leftEditor: Editor, rightEditor: Editor) {
+	const leftTop = leftEditor.rootElement.getBoundingClientRect().y;
+	const rightTop = rightEditor.rootElement.getBoundingClientRect().y;
+	const leftScrollTop = leftEditor.rootElement.scrollTop;
+	const rightScrollTop = rightEditor.rootElement.scrollTop;
+
+	const offenders: Record<string, unknown>[] = [];
+	let prevLeftY = Number.NEGATIVE_INFINITY;
+	let prevRightY = Number.NEGATIVE_INFINITY;
+
+	for (let i = 0; i < anchorPairs.length; i++) {
+		const p = anchorPairs[i];
+		const measurable =
+			p.leftEl.isConnected &&
+			p.leftEl.offsetParent !== null &&
+			p.rightEl.isConnected &&
+			p.rightEl.offsetParent !== null;
+		if (!measurable) {
+			offenders.push({ index: i, reason: "unmeasurable(skip)", diffIndex: p.diffIndex });
+			continue;
+		}
+
+		const leftY = p.leftEl.getBoundingClientRect().y + leftScrollTop - leftTop;
+		const rightY = p.rightEl.getBoundingClientRect().y + rightScrollTop - rightTop;
+		const residual = Math.round(leftY - rightY);
+
+		const nonMonotonic = leftY < prevLeftY || rightY < prevRightY;
+		if (!nonMonotonic) {
+			prevLeftY = leftY;
+			prevRightY = rightY;
+		}
+
+		if (residual < -1 || residual > 1) {
+			offenders.push({
+				index: i,
+				residual,
+				delta: p.delta,
+				reason: nonMonotonic ? "non-monotonic(skip)" : "processed-but-off",
+				diffIndex: p.diffIndex,
+				left: p.leftEl.nodeName,
+				right: p.rightEl.nodeName,
+				leftPad: p.leftEl.style.getPropertyValue("--ds-adjust") || "-",
+				rightPad: p.rightEl.style.getPropertyValue("--ds-adjust") || "-",
+			});
+		}
+	}
+
+	if (offenders.length) {
+		console.warn(
+			`[alignAnchors] ${offenders.length}/${anchorPairs.length} pair(s) still misaligned >1px after pass`,
+		);
+		console.table(offenders);
 	}
 }
 

--- a/core/src/engine/process-diff-elements.ts
+++ b/core/src/engine/process-diff-elements.ts
@@ -336,6 +336,17 @@ export async function processDiffElements({
 			delta = rightAdjust;
 		}
 
+		// [both-padding 방어] adjust 장부는 skip된 pair에서 갱신되지 않아 stale(0)일 수
+		// 있으므로 실제 CSS(ds-padded)를 ground truth로 재확인한다. 한 pair에 양쪽
+		// 패딩이 동시에 남아있는 것은 불가능한 상태 → 둘 다 제거하고 재계산에 맡긴다.
+		if (leftEl.classList.contains("ds-padded") && rightEl.classList.contains("ds-padded")) {
+			leftEl.classList.remove("ds-padded", "ds-striped");
+			leftEl.style.removeProperty("--ds-adjust");
+			rightEl.classList.remove("ds-padded", "ds-striped");
+			rightEl.style.removeProperty("--ds-adjust");
+			delta = 0;
+		}
+
 		activateAnchorEl(leftEl, index, diffIndex);
 		activateAnchorEl(rightEl, index, diffIndex);
 		anchorPairs.push({

--- a/core/tests/align-anchors.test.ts
+++ b/core/tests/align-anchors.test.ts
@@ -485,4 +485,41 @@ describe("alignAnchors — 방어 가드", () => {
 		expect(l2.classList.contains("ds-padded")).toBe(false);
 		expect(r2.classList.contains("ds-padded")).toBe(false);
 	});
+
+	it("[표/다단] 양쪽이 함께 역행(새 열 시작)하면 교차 역전이 아니므로 적용", async () => {
+		// 표 셀/다단에서 다음 열이 시작되면 좌우 앵커 Y가 함께 위로 돌아간다.
+		// 이는 발산을 유발하는 "한쪽만 역행(교차 역전)"이 아니므로 적법 → 적용되어야 함.
+		// (예전 OR 가드에서는 이 적법한 앵커가 잘못 skip되었다.)
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		// pair1: 첫 열의 아래쪽 줄
+		const l1 = makeDsAnchor();
+		const r1 = makeDsAnchor();
+		mockGBCR(l1, 400);
+		mockGBCR(r1, 500);
+		const pair1 = createAnchorPair(l1, r1, 0, markerElements, 0);
+
+		// pair2: 다음 셀/열의 첫 줄 → 양쪽 모두 Y 감소 (coordinated reset)
+		const l2 = makeDsAnchor();
+		const r2 = makeDsAnchor();
+		mockGBCR(l2, 100);
+		mockGBCR(r2, 130);
+		const pair2 = createAnchorPair(l2, r2, 0, markerElements, 1);
+
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair1, pair2],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		expect(pair1.delta).toBe(-100); // 400-500 → left에 100px
+		// 핵심: pair2도 적용되어야 함
+		expect(pair2.delta).toBe(-30); // 100-130 → left에 30px
+		expect(l2.classList.contains("ds-padded")).toBe(true);
+	});
 });

--- a/core/tests/align-anchors.test.ts
+++ b/core/tests/align-anchors.test.ts
@@ -357,6 +357,73 @@ describe("alignAnchors — 패딩 방향 전환", () => {
 	});
 });
 
+describe("alignAnchors — 양쪽 패딩(both-padding) 방어", () => {
+	it("양쪽에 ds-padded가 남아있으면 정규화하여 최대 한쪽만 패딩", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		const leftEl = makeDsAnchor();
+		const rightEl = makeDsAnchor();
+		// 불가능한 상태를 인위적으로 구성: 양쪽 모두 ds-padded
+		mockGBCR(leftEl, 150);
+		mockGBCR(rightEl, 100);
+		const pair = createAnchorPair(leftEl, rightEl, 0, markerElements);
+		leftEl.style.setProperty("--ds-adjust", "20px");
+		leftEl.classList.add("ds-padded");
+		rightEl.style.setProperty("--ds-adjust", "30px");
+		rightEl.classList.add("ds-padded");
+
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		// 정규화로 둘 다 제거된 뒤, 실제 위치(150 vs 100)로 right에만 재적용
+		expect(pair.delta).toBe(50);
+		expect(rightEl.classList.contains("ds-padded")).toBe(true);
+		expect(rightEl.style.getPropertyValue("--ds-adjust")).toBe("50px");
+		expect(leftEl.classList.contains("ds-padded")).toBe(false);
+		expect(leftEl.style.getPropertyValue("--ds-adjust")).toBe("");
+	});
+
+	it("양쪽 ds-padded + 위치 정렬(delta 0)이면 둘 다 제거", async () => {
+		const left = createMockEditor(0);
+		const right = createMockEditor(0);
+		const markerElements: MarkerElementsMap = new Map();
+
+		const leftEl = makeDsAnchor();
+		const rightEl = makeDsAnchor();
+		// 박스 top이 같음(정렬) → 정규화로 둘 다 제거되고 재적용 없음
+		mockGBCR(leftEl, 100);
+		mockGBCR(rightEl, 100);
+		const pair = createAnchorPair(leftEl, rightEl, 0, markerElements);
+		leftEl.style.setProperty("--ds-adjust", "20px");
+		leftEl.classList.add("ds-padded");
+		rightEl.style.setProperty("--ds-adjust", "30px");
+		rightEl.classList.add("ds-padded");
+
+		const controller = new AbortController();
+		await alignAnchors({
+			anchorPairs: [pair],
+			leftEditor: left,
+			rightEditor: right,
+			markerElements,
+			signal: controller.signal,
+		});
+
+		expect(pair.delta).toBe(0);
+		expect(leftEl.classList.contains("ds-padded")).toBe(false);
+		expect(rightEl.classList.contains("ds-padded")).toBe(false);
+		expect(leftEl.style.getPropertyValue("--ds-adjust")).toBe("");
+		expect(rightEl.style.getPropertyValue("--ds-adjust")).toBe("");
+	});
+});
+
 // ══════════════════════════════════════════════════════════════════
 
 describe("alignAnchors — 방어 가드", () => {

--- a/core/tests/editor-mutation-cleanup.test.ts
+++ b/core/tests/editor-mutation-cleanup.test.ts
@@ -1,0 +1,63 @@
+/**
+ * cleanCopiedAnchorAttrs: 에디터 MutationObserver가 added node에서 마커 잔여 attr을
+ * 제거하는 로직. 핵심 불변식:
+ *   - 브라우저가 줄 분할 시 복사한 '컨텐츠 블록'(p/div/td 등)의 data-anchor-index는 제거.
+ *   - 엔진이 직접 삽입한 DS-ANCHOR / DS-DIFF는 절대 건드리지 않음
+ *     (삽입 직후 동기 설정한 index를 옵저버 콜백이 지워버리는 버그 방지).
+ */
+import { describe, it, expect } from "vitest";
+import { cleanCopiedAnchorAttrs } from "../src/editor/editor";
+import { ANCHOR_TAG_NAME, DIFF_TAG_NAME } from "../src/constants";
+
+function padded(el: HTMLElement, index: string) {
+	el.dataset.anchorIndex = index;
+	el.dataset.diffIndex = "5";
+	el.classList.add("ds-padded", "ds-striped");
+	el.style.setProperty("--ds-adjust", "12px");
+	return el;
+}
+
+describe("cleanCopiedAnchorAttrs", () => {
+	it("[회귀] 엔진이 삽입한 DS-ANCHOR의 index/패딩은 건드리지 않는다", () => {
+		const el = padded(document.createElement(ANCHOR_TAG_NAME), "0");
+		cleanCopiedAnchorAttrs(el);
+		expect(el.dataset.anchorIndex).toBe("0");
+		expect(el.classList.contains("ds-padded")).toBe(true);
+		expect(el.style.getPropertyValue("--ds-adjust")).toBe("12px");
+	});
+
+	it("[회귀] 엔진이 삽입한 DS-DIFF도 건드리지 않는다", () => {
+		const el = padded(document.createElement(DIFF_TAG_NAME), "1");
+		cleanCopiedAnchorAttrs(el);
+		expect(el.dataset.anchorIndex).toBe("1");
+		expect(el.classList.contains("ds-padded")).toBe(true);
+	});
+
+	it("브라우저가 복사한 컨텐츠 블록(p)의 잔여 attr은 제거한다", () => {
+		const el = padded(document.createElement("p"), "3");
+		cleanCopiedAnchorAttrs(el);
+		expect(el.dataset.anchorIndex).toBeUndefined();
+		expect(el.dataset.diffIndex).toBeUndefined();
+		expect(el.classList.contains("ds-padded")).toBe(false);
+		expect(el.style.getPropertyValue("--ds-adjust")).toBe("");
+	});
+
+	it("borrow 블록(td) 복사본도 제거 대상", () => {
+		const el = padded(document.createElement("td"), "2");
+		cleanCopiedAnchorAttrs(el);
+		expect(el.dataset.anchorIndex).toBeUndefined();
+		expect(el.classList.contains("ds-padded")).toBe(false);
+	});
+
+	it("data-anchor-index가 없는 노드는 그대로 둔다", () => {
+		const el = document.createElement("p");
+		el.classList.add("some-class");
+		cleanCopiedAnchorAttrs(el);
+		expect(el.classList.contains("some-class")).toBe(true);
+	});
+
+	it("텍스트 노드는 무시한다", () => {
+		const text = document.createTextNode("hello");
+		expect(() => cleanCopiedAnchorAttrs(text)).not.toThrow();
+	});
+});

--- a/docs/alignanchor-investigation.md
+++ b/docs/alignanchor-investigation.md
@@ -203,6 +203,17 @@ tokenize → diff worker(buildPatienceAnchors→processSegmentsWithAnchors)
 ### (F) `alignAnchors`는 단일 패스 — [설계 확인, 이슈 아님]
 fixpoint 반복이 아니다. 위→아래로 가며 상단 조정이 하단 측정에 반영되므로 한 패스로 수렴한다. 리사이즈/스크롤/diff 이벤트로만 재실행. 의도된 설계로 확인됨.
 
+### (G) 정렬 후에도 좌우 Y가 5px+ 어긋나는 잔차 — [조사 중]
+
+**모델 재검증(중요):** `line_content_y = anchorBoxTop + pad`, `pad = -(leftY - rightY)`이므로 측정값(박스 top 차이)이 곧 정확한 보정량이다. 즉 **처리된(processed) pair는 round() 오차(≤1px) 내로 정렬된다.** 앵커 사이 누적 오프셋도 다음 공통 앵커에서 즉시 리셋된다. 따라서 5px+ 잔차는 "누적 드리프트"가 **아니다.**
+
+남는 이산적(discrete) 후보는 셋뿐이다:
+- **(a) skip된 pair** — 가시성/단조성 가드(`align-anchors.ts:63,79`)에 걸려 처리 자체가 안 됨.
+- **(b) 무앵커 줄** — 앵커 쌍은 **양쪽 모두 `LINE_START`**일 때만 생성(`process-diff-elements.ts:355,488`). 다음 공통 앵커가 멀면 그 구간 내부가 어긋난 채 남음.
+- **(c) 처리됐지만 padding이 물리적으로 안 먹은 pair** — 예: `<DS-DIFF>.ds-line-start`의 `height: calc(--ds-line-height*1em) !important`(`core.css:276`)와 `::before` 패딩의 상호작용, 또는 borrow 블록의 특수 케이스.
+
+**진단 방법:** DEV 빌드에서 `alignAnchors` 종료 시 각 pair를 재측정해 1px 초과 잔차를 `console.table`로 보고하는 계측을 추가했다(`align-anchors.ts` `diagnoseResidual`). 콘솔의 `reason` 컬럼으로 (a)`non-monotonic(skip)`/`unmeasurable(skip)` vs (c)`processed-but-off`를 구분해 원인을 확정한다. 실제 재현 문서에서 이 로그를 확보하면 (a)/(b)/(c) 중 무엇인지 판별 가능.
+
 ---
 
 ## 7. 테스트 커버리지 평가

--- a/docs/alignanchor-investigation.md
+++ b/docs/alignanchor-investigation.md
@@ -1,0 +1,232 @@
+# AlignAnchor 면밀 조사 (Deep Investigation)
+
+> 조사 대상: sync mode(F2) 정렬을 담당하는 **anchor** 파이프라인.
+> 조사 일자: 2026-07-01 · 대상 브랜치: `claude/alignanchor-investigation-0e5jj4`
+> 기준 커밋: `d551207` (Merge #120)
+
+이 문서는 DiffSeek의 "anchor" 정렬 메커니즘을 코드 레벨에서 끝까지 추적한 결과다.
+파일:라인 참조는 모두 위 기준 커밋 기준.
+
+---
+
+## 0. 핵심 요약 (TL;DR)
+
+- **"anchor"라는 이름은 두 개의 완전히 다른 개념에 재사용된다.**
+  1. `DiffAnchor` — diff 알고리즘 레벨. 매칭된 **토큰 범위**. (`core/src/diff/types.ts:87`)
+  2. `AnchorPair` — 렌더/정렬 레벨. 두 에디터의 **DOM 요소 쌍**과 픽셀 delta. (`core/src/engine/types.ts:48`)
+  둘은 이름만 공유할 뿐 자료구조·목적·수명주기가 다르다. "alignanchor"가 가리키는 것은 **후자(`AnchorPair` + `align-anchors.ts`)** 이다.
+- 정렬은 `<DS-ANCHOR>` 요소의 `::before` pseudo-element 높이(`--ds-adjust`)를 조절해 **한 쪽 에디터에 세로 패딩을 주입**하는 방식이다. Canvas가 아니라 실제 레이아웃을 건드린다.
+- 알고리즘은 **위→아래 단일 패스**로, 각 pair의 raw `getBoundingClientRect().y` 차이를 delta로 삼는다. 반복(fixpoint) 없음 — 위쪽 조정이 아래쪽 측정에 이미 반영되므로 한 패스로 대체로 수렴한다.
+- 과거 회귀의 대부분은 **gBCR 보정(correction) 로직**에서 나왔고, 현재는 보정을 전부 제거하고 raw 값을 쓰는 것이 정답으로 확정됐다 (`d266a41`). 여기에 손대면 안 된다.
+- 발견된 이슈: (A) 문서 stale 참조, (B) `AnchorPair`의 4개 write-only 필드, (C) `delta==0` 재조정 시 0px `ds-padded` 잔존, (D) `processSegmentsWithAnchors`의 gap suffix-trim 비대칭, (E) Y 단조성 가정의 다단 레이아웃 취약성. 상세는 §6.
+
+---
+
+## 1. 두 개의 "anchor" 개념
+
+### 1.1 `DiffAnchor` — 토큰 범위 (diff 워커 내부)
+
+```ts
+// core/src/diff/types.ts:87
+export type DiffAnchor = { lhsStart; lhsEnd; rhsStart; rhsEnd; };  // 토큰 인덱스
+```
+
+- 생성: `buildPatienceAnchors()` (`core/src/diff/patience-diff.ts:10`)
+- 소비: `processSegmentsWithAnchors(ctx, lhs, rhs, anchors)` (`core/src/diff/process-segments-with-anchors.ts:20`)
+- 역할: patience 경로에서 "확실히 일치하는 토큰 구간"을 앵커로 고정하고, 앵커 **사이의 gap만** `runHistogramDiff`로 재diff. 앵커 구간 자체는 `markUnchanged`로 UNCHANGED 처리.
+- 호출 위치: 워커 `core/src/diff-worker/worker.ts:157-159`.
+
+즉 이건 **diff 정확도/성능용 내부 최적화**이며 sync mode와 무관하다.
+
+### 1.2 `AnchorPair` — DOM 요소 쌍 (엔진/렌더)
+
+```ts
+// core/src/engine/types.ts:48
+export type AnchorPair = {
+  index: number;
+  leftEl: HTMLElement;         // <DS-ANCHOR> 또는 borrow된 블록
+  rightEl: HTMLElement;
+  diffIndex: number | null;
+  leftContainerIndex: number;
+  rightContainerIndex: number;
+  delta: number;               // 현재 적용된 패딩(px), 부호 = 방향
+};
+```
+
+- 생성: `processDiffElements()` → `addAnchorPair()` (`core/src/engine/process-diff-elements.ts:314`)
+- 저장: `DiffContext.anchorPairs` (`core/src/engine/types.ts:28`)
+- 소비: `alignAnchors()` (`core/src/engine/align-anchors.ts:10`)
+
+이하 문서에서 "anchor"는 이 `AnchorPair`를 의미한다.
+
+---
+
+## 2. 정렬용 anchor의 생성 (`process-diff-elements.ts`)
+
+diff 결과 버퍼를 순회(`:577`)하며 청크 단위로 UNCHANGED/DIFF를 구분(`extendOrFlush`/`flushChunk`)하고, 두 경로에서 anchor를 만든다.
+
+- **UNCHANGED 라인** → `handleCommon()` (`:352`)
+  - 양쪽 첫 토큰이 **둘 다 `LINE_START`** 일 때만 (`:355`) 앵커 쌍 생성.
+  - `getAnchorElForLine()` (`:286`)로 각 줄 시작 위치에 `<DS-ANCHOR>` 확보 → `addAnchorPair(…, diffIndex=null, …)`.
+- **DIFF 라인** → `handleDiff()` (`:364`)
+  - 양쪽 다 내용 있음: 양쪽 `LINE_START`면 앵커 쌍 생성(`:488`).
+  - 한 쪽 empty/structural-only: 빈 쪽에 `<DS-DIFF>` 마커를 만들고(`getDiffMarkerEl`), 채워진 쪽 줄 시작에 앵커를 확보해 **빈 쪽은 `<DS-DIFF>`를 borrow**해서 쌍을 만든다(`:414-433`).
+
+### 2.1 `addAnchorPair`의 delta seeding (연속성)
+
+```
+// process-diff-elements.ts:314
+leftAdjust  = prevMarkerElements?.get(leftEl)?.adjust  ?? 0
+rightAdjust = prevMarkerElements?.get(rightEl)?.adjust ?? 0
+```
+
+이전 run에서 재사용된 요소의 패딩값을 그대로 `delta` 초기값으로 물려받아, 다음 `alignAnchors`가 "이미 맞춰진 상태"에서 시작하도록 한다. → diff run마다 정렬이 깜빡이는 것을 방지.
+- 양쪽 모두 adjust가 있으면(서로 다른 pair 출신) delta=0으로 리셋하고 양쪽 패딩 제거(`:326-332`).
+
+### 2.2 마커 요소 수명주기
+
+- `<DS-ANCHOR>`(`ANCHOR_TAG_NAME`), `<DS-DIFF>`(`DIFF_TAG_NAME`)는 run 간 **재사용**된다. `markerElements`(현재 run) / `prevMarkerElements`(직전 run) 두 맵으로 관리.
+- `beginMarkerUpdate`/`endMarkerUpdate`(`diffseek-engine.ts:687,695`)가 스왑·정리. `cleanupUnusedMarkers`(`:186`)가 미재사용 마커 제거 및 borrow된 블록의 class/style/dataset 정리.
+- borrow: `afterbegin`일 때 컨테이너 자체(예: `<td>`)를 앵커로 빌려 DOM 삽입 없이 사용(`:61`).
+
+이 수명주기는 회귀 다발 지점이며 전용 테스트로 잠겨 있다 (`marker-and-anchor-dom.test.ts`, #111 회귀).
+
+---
+
+## 3. 정렬 실행 (`align-anchors.ts`)
+
+`alignAnchors({anchorPairs, leftEditor, rightEditor, markerElements, signal, scrollRestore})`.
+
+### 3.1 측정과 delta
+
+각 pair에 대해 (`:73`):
+
+```
+leftY  = leftEl.gBCR().y  + leftScrollTop  - leftEditorTop
+rightY = rightEl.gBCR().y + rightScrollTop - rightEditorTop
+delta  = round(leftY - rightY)      // :98  raw, 보정 없음
+```
+
+- `delta > 0` → 왼쪽이 더 아래 → **오른쪽에** `|delta|` 패딩.
+- `delta < 0` → **왼쪽에** 패딩.
+- `applyDeltaToPair`(`:183`)가 반대쪽 패딩 제거 후 `--ds-adjust`/`ds-padded`(+`ds-striped`) 부여, `markerElements[el].adjust` 갱신.
+
+**중요 불변식**: `::before` 패딩은 요소 top(gBCR.y)에 영향을 주지 않으므로 별도 보정이 필요 없다. 과거 보정 로직이 이 사실을 오해해 delta 부호를 뒤집는 버그를 냈다(§5).
+
+### 3.2 방어 가드 (모두 최근 추가, `e0e8e38`)
+
+1. **가시성 가드**(`:63`): `!isConnected || offsetParent===null`이면 skip. display:none 조상 하에서 gBCR이 0을 반환해 발산 패딩을 만드는 것을 차단.
+2. **단조성 가드**(`:79`): `leftY < prevLeftY || rightY < prevRightY`면 skip. anchor가 문서 순서상 아래인데 화면 Y가 역전되면, 적용 시 다음 pair가 이전 pair로 역피드백되어 발산 → 방지.
+3. **임계값**(`:100`): `|delta - pair.delta| <= MIN_DELTA(1)`이면 재조정 안 함(steady-state no-op).
+
+### 3.3 스크롤 앵커링 보정
+
+- 패딩을 뷰포트 위 요소에 주입하면 브라우저가 `scrollTop`을 자동 조정한다. 그래서 적용 직후 `scrollTop`을 다시 읽는다(`:104-105`).
+- `adjustedAboveViewportBottom`이면 프레임 yield 시점에 저장된 스크롤로 복원(`:141`, `:156`).
+- yield 전후 `scrollTop` 비교로 **사용자 스크롤을 감지하면 복원 포기**(`:129-139`).
+
+### 3.4 높이 보정 (마지막 단계, `:163`)
+
+두 에디터의 `contentElement.offsetHeight`를 비교해 짧은 쪽 `heightBoostElement.style.height`로 하단을 채워 스크롤 범위를 맞춘다.
+
+### 3.5 배치/yield
+
+`BATCH_SIZE=16`, 10ms(`IDLE_THRESHOLD`) 넘으면 `nextAnimationFrame`으로 양보. `AbortSignal`로 취소 가능.
+
+---
+
+## 4. 트리거 & 오케스트레이션 (`diffseek-engine.ts`)
+
+`alignAnchors`(엔진 private, `:842`)는 abort controller로 감싸 3곳에서 호출:
+
+1. **F2 토글 ON** — `set syncMode`(`:397`) → rAF 안에서 `alignAnchors(preSaved)` (`:422`). 사전에 스크롤 저장(`:407`), 읽기 전용 전환.
+2. **diff workflow 종료 후** — `startDiffWorkflow`(`:815-817`) `syncMode`면 재정렬.
+3. **에디터 리사이즈** — `handleEditorResize`(`:368-369`) 폭 변화 시.
+
+취소: `cancelOngoingOperations`(`:677`)에서 abort. sync scroll은 별도(`syncScroll`, `:338`)로 rAF 디바운스.
+
+전체 파이프라인:
+
+```
+tokenize → diff worker(buildPatienceAnchors→processSegmentsWithAnchors)
+        → processDiffElements() → DiffContext.anchorPairs
+        → (syncMode?) alignAnchors() → <DS-ANCHOR>.style --ds-adjust → CSS ::before 패딩
+```
+
+---
+
+## 5. 회귀 이력 (왜 지금 코드가 이렇게 생겼나)
+
+| 커밋 | 문제 | 해결 | 테스트 |
+|---|---|---|---|
+| `489f244` (#100) | ::before 보정 **부호 반전** → 재실행마다 누적 드리프트 | 부호 뒤집음(임시) | — (후속에 의해 대체) |
+| `d266a41` | 위 보정 자체가 근본적으로 틀림(gBCR.y는 ::before 무관). 부호 뒤집힘 + borrow 블록에서 비대칭 | **보정 전면 제거**, raw `leftY-rightY` 사용 | `align-anchors.test.ts:255,291` (회귀 잠금) |
+| `e0e8e38` | 무효 측정/비단조 Y → 화면을 채우는 발산 패딩 | 가시성·단조성 가드 추가 | `align-anchors.test.ts:362-487` |
+| `6669270` (#111) | 2회차 run에서 `<DS-ANCHOR>`가 `<DS-DIFF>` 앞에 옴 | `beforebegin` 역방향 walk | `marker-and-anchor-dom.test.ts:514` |
+| `4fb0e8f` | 비인접 empty-side diff가 하나로 병합 | 인접성 체크 추가 | `process-diff-elements.test.ts:951` |
+| `7403134` | structural-only일 때 left/right range 스왑 | `leftCount===0 || leftStructuralOnly` | `process-diff-elements.test.ts:203` |
+| `2f2a63c`/`00280a9` | sync mode 스크롤 드리프트 / 사용자 스크롤 중 복원 | 스크롤 save/restore 정리 | — |
+
+**교훈(반복 금지):** `align-anchors.ts`의 delta는 **절대 gBCR 보정하지 말 것**. 보정처럼 보이는 코드를 다시 넣으면 §5의 `d266a41` 회귀 테스트가 잡는다.
+
+---
+
+## 6. 발견 사항 (Findings)
+
+정확도 순. 대부분 저위험이지만 정리해 둔다.
+
+### (A) 문서 stale 참조 — `CLAUDE.md` [문서]
+`CLAUDE.md`의 Key Source Files 표와 "Architecture Patterns"는 정렬 로직을
+`core/src/engine/anchor-manager.ts`("Identifies matching line pairs")로 기술하지만
+**그 파일은 존재하지 않는다.** 실제 구현은 `align-anchors.ts`(정렬) + `process-diff-elements.ts`(앵커 생성)로 분리돼 있다.
+→ 신규 기여자가 잘못된 파일을 찾게 만든다. 표 갱신 권장.
+
+### (B) `AnchorPair`의 write-only 필드 4개 — `types.ts:48` [죽은 데이터]
+`index`, `diffIndex`, `leftContainerIndex`, `rightContainerIndex`는 `addAnchorPair`에서 **채워지지만 소스 어디에서도 읽히지 않는다**(grep 확인: `core/src/**` 내 읽는 곳 0). `alignAnchors`가 쓰는 것은 `leftEl`, `rightEl`, `delta`뿐.
+- `diffIndex`는 요소의 `dataset.diffIndex`로는 쓰이지만(`activateAnchorEl`) pair 필드로는 안 읽힘.
+- `containerIndex`는 앵커를 컨테이너(td) 경계별로 그루핑하려던 **미완/유보 기능의 흔적**으로 보인다.
+→ 향후 계획이 없다면 제거해 자료구조를 단순화하거나, 계획이 있으면 주석으로 의도를 남길 것.
+
+### (C) `delta==0`일 때 0px `ds-padded` 잔존 — `align-anchors.ts:100,183` [사소]
+`pair.delta`가 예: 2였다가 이번에 0이 되면 `deltadelta=-2`로 `applyDeltaToPair(pair, 0, …)` 호출.
+`delta>0`가 false → else 분기에서 `theEl=leftEl`에 `--ds-adjust:0px` + `ds-padded` 부여(높이 0). `ds-striped`는 `0>=1` 실패로 안 붙음.
+→ 시각적 영향 없음(0px). 다만 `ds-padded` class가 불필요하게 남는다. `delta===0`이면 양쪽 패딩만 제거하도록 조기 처리하면 깔끔.
+
+### (D) gap suffix-trim 비대칭 — `process-segments-with-anchors.ts:103-148` [정합성]
+`whitespace:ignore`에서 **마지막 tail gap**은 `matchSuffixTokens`로 교차경계 접미 매칭을 하지만(`:129-147`), **앵커 사이 중간 gap**의 동일 로직은 **주석 처리**돼 있다(`:103-114`). 중간 gap은 `diff()`(→`runHistogramDiff` + n\*m fallback)에 위임한다.
+→ 기능상으로는 fallback이 커버하므로 결과는 맞을 가능성이 높지만, "tail만 특별대우"라는 비대칭은 의도인지 확인 필요. 의도라면 주석으로 근거를 남기고, 아니라면 죽은 주석 블록 제거.
+
+### (E) Y 단조성 가정 — `align-anchors.ts:48-51,79` [설계 가정]
+가드는 "diff 단조성 → anchor의 화면 Y도 단조 증가"를 전제한다. 하지만 앵커는 문서 순서로 push되고, **다단/표 레이아웃**(좌우로 배치된 셀)에서는 문서 순서와 화면 Y 순서가 어긋날 수 있다. 이 경우 정상적인 pair도 비단조로 판정돼 **skip**된다(정렬 누락) — 발산보다는 안전한 실패지만, 표가 많은 한국 법령 문서에서 일부 줄이 정렬 안 될 수 있다.
+→ 현재는 "안전하게 포기"라 버그는 아니지만, 표 중심 문서에서 정렬 품질 저하 가능성으로 기록.
+
+### (F) `alignAnchors`는 단일 패스 — [설계 확인, 이슈 아님]
+fixpoint 반복이 아니다. 위→아래로 가며 상단 조정이 하단 측정에 반영되므로 한 패스로 수렴한다. 리사이즈/스크롤/diff 이벤트로만 재실행. 의도된 설계로 확인됨.
+
+---
+
+## 7. 테스트 커버리지 평가
+
+| 파일 | 대상 | 상태 |
+|---|---|---|
+| `align-anchors.test.ts` (489L) | delta 계산, borrow 블록 혼합, 방향 전환, 4개 방어 가드 | 견고. `.skip`/`.only`/TODO 없음. jsdom gBCR을 mock. |
+| `marker-and-anchor-dom.test.ts` (593L) | `getOrCreateAnchor`/`getOrCreateEmptyDiffMarker`/`cleanupUnusedMarkers`, #111 회귀 | 견고. DOM 수명주기 커버. |
+| `process-diff-elements.test.ts` (1399L) | structural-only 스왑, 비인접 병합 방지, empty-side, 분기 커버 | 견고. |
+
+**커버 안 되는 영역(권장 보강):**
+1. **다중 pair의 순차 상호작용** — 위 pair 패딩이 아래 pair 측정에 미치는 영향을 실제 레이아웃으로 검증하는 테스트가 없다(가드 테스트는 mock Y라 상호작용 없음). jsdom 한계상 e2e/브라우저 필요.
+2. **스크롤 앵커링/복원 경로**(`:104-159`) — mock 에디터에서 `scrollTop` 변화 시나리오 미검증.
+3. **height boost**(`:163-174`) — 결과 높이 산출 미검증.
+4. **엔진 트리거 3경로**(F2/diff후/resize)와 abort 취소의 결합 — 통합 테스트 부재.
+
+---
+
+## 8. 권장 조치 (우선순위)
+
+1. **[문서]** `CLAUDE.md`의 `anchor-manager.ts` 참조를 `align-anchors.ts` + `process-diff-elements.ts`로 정정. (즉시, 무위험) — §6-A
+2. **[정리]** `AnchorPair`의 미사용 4필드 제거 또는 의도 주석. — §6-B
+3. **[미세]** `delta===0` 조기 처리로 0px `ds-padded` 잔존 제거. — §6-C
+4. **[확인]** `process-segments-with-anchors.ts`의 주석 처리된 중간 gap suffix-trim이 의도인지 원작자 확인 후 주석/삭제. — §6-D
+5. **[테스트]** 다중 pair 순차 상호작용 및 스크롤 복원 경로에 대한 통합/브라우저 테스트 추가. — §7
+
+> ⚠️ **하지 말 것:** `align-anchors.ts`의 raw delta에 gBCR 보정 재도입(§5 회귀), 가시성/단조성 가드 제거(§3.2), 마커 재사용 로직 단순화(§2.2 #111 회귀). 모두 전용 회귀 테스트가 지키고 있으며 과거에 실제로 깨졌다.

--- a/docs/alignanchor-investigation.md
+++ b/docs/alignanchor-investigation.md
@@ -325,3 +325,42 @@ else { prevLeftY = leftY; prevRightY = rightY; /* 적용 */ }
 - 전체 507 테스트 통과.
 
 > 근본적으로는 skip 경로에서 `markerElements.adjust`를 실제 상태와 동기화하지 않는 **장부-CSS 불일치**가 원인이다. 위 수정은 CSS를 ground truth로 삼아 불일치의 영향을 무력화한다. 장부 자체를 항상 정합하게 유지하는 리팩터링(§6-B의 필드 정리와 함께)은 후속 과제로 남긴다.
+
+---
+
+## 11. 앵커 인덱스 어긋남 — MutationObserver가 방금 삽입한 앵커의 index를 지움
+
+### 11.1 증상
+
+DOM에서 좌우 앵커의 `data-anchor-index`가 어긋나 보인다. 예: 왼쪽 `1,2,3,…` / 오른쪽 `0,1,2,…`.
+
+### 11.2 `data-anchor-index`는 페어링 키가 아니다 (먼저 확인)
+
+전 사용처는 5곳뿐이다: 설정(`activateAnchorEl`, `process-diff-elements.ts:306`), 삭제(`cleanupUnusedMarkers:199`, `editor.ts` MutationObserver), CSS presence 셀렉터(`core.css:292` — 있으면 `display:block`). **`alignAnchors`는 이 값을 좌우 대응에 쓰지 않고 `anchorPairs` 배열의 `leftEl`/`rightEl` 참조로 직접 페어링**한다. 그리고 `addAnchorPair`는 한 pair의 양쪽에 **같은 index**를 부여한다(`activateAnchorEl(leftEl, index)` / `(rightEl, index)`). 따라서 index 값 자체가 정렬 대응을 결정하지 않는다.
+
+### 11.3 진짜 원인: 에디터 MutationObserver의 오제거 (프로브로 확인)
+
+`editor.ts`의 `onMutation`은 **added node** 중 `data-anchor-index`를 가진 것의 index·패딩을 제거한다. 원래 목적은 *"브라우저가 줄 분할(Enter) 시 기존 줄의 attr을 새 줄로 복사"* 하는 것을 청소하는 것이다.
+
+그런데 이 옵저버는 **diff 파이프라인 동안 끊기지 않는다**(paste 때만 `unobserveMutation`). 그리고:
+
+1. `getOrCreateAnchor`가 `DS-ANCHOR`를 **생성·삽입**(이 시점엔 index 없음).
+2. `addAnchorPair`→`activateAnchorEl`이 **동기적으로** `data-anchor-index` 설정.
+3. MutationObserver 콜백은 **다음 microtask**에 실행 → 이때 added node는 이미 index를 가짐 → **제거됨.**
+
+이는 jsdom 프로브로 확정했다: 삽입 직후 동기 설정한 index가 콜백 후 `undefined`로 사라진다.
+
+**결과:**
+- 새로 삽입된 앵커가 `[data-anchor-index]`를 잃음 → sync mode CSS에서 `display:none` → `offsetParent===null` → `alignAnchors` 가시성 가드(§9.2 A1)에 걸려 **skip** → 첫 등장 시 정렬 누락.
+- **재사용** 앵커는 삽입이 아니라 attribute 변경으로 index가 갱신되므로(childList 미관측) 살아남음. borrow 블록(td/p/contentElement)도 pre-existing이라 살아남음.
+- 따라서 좌우가 **신규 삽입 vs 재사용/borrow 비율이 다르면** DOM index가 어긋나 보인다 → "왼쪽 1,2,3 / 오른쪽 0,1,2".
+
+### 11.4 수정 (surgical)
+
+`onMutation`의 청소 대상에서 **엔진이 직접 삽입·관리하는 `DS-ANCHOR`/`DS-DIFF`를 제외**한다. 이 요소들은 브라우저 복사 대상이 아니며(복사되는 건 컨텐츠 블록 p/div/td), `markerElements`/`cleanupUnusedMarkers`로 별도 관리된다. 브라우저가 복사한 컨텐츠 블록의 잔여 attr 청소라는 원래 목적은 그대로 유지된다.
+
+- 결정 로직을 순수 함수 `cleanCopiedAnchorAttrs(node)`로 추출(`editor.ts`) → 단위 테스트 가능화.
+- 신규 테스트 `editor-mutation-cleanup.test.ts`(6개): DS-ANCHOR/DS-DIFF 보존 / p·td 복사본 제거 / 무관 노드 무시.
+- 전체 513 테스트 통과.
+
+> 대안으로 diff 파이프라인 동안 옵저버를 disconnect(paste 방식)하는 방법도 있으나, 비동기 `processDiffElements`의 yield 구간 동안 사용자 편집 mutation이 유실될 수 있어 blast radius가 크다. DS-ANCHOR/DS-DIFF만 제외하는 편이 목적에 정확히 부합하고 부작용이 없다.

--- a/docs/alignanchor-investigation.md
+++ b/docs/alignanchor-investigation.md
@@ -240,4 +240,58 @@ fixpoint 반복이 아니다. 위→아래로 가며 상단 조정이 하단 측
 4. **[확인]** `process-segments-with-anchors.ts`의 주석 처리된 중간 gap suffix-trim이 의도인지 원작자 확인 후 주석/삭제. — §6-D
 5. **[테스트]** 다중 pair 순차 상호작용 및 스크롤 복원 경로에 대한 통합/브라우저 테스트 추가. — §7
 
-> ⚠️ **하지 말 것:** `align-anchors.ts`의 raw delta에 gBCR 보정 재도입(§5 회귀), 가시성/단조성 가드 제거(§3.2), 마커 재사용 로직 단순화(§2.2 #111 회귀). 모두 전용 회귀 테스트가 지키고 있으며 과거에 실제로 깨졌다.
+> ⚠️ **하지 말 것:** `align-anchors.ts`의 raw delta에 gBCR 보정 재도입(§5 회귀), 가시성 가드 제거(§3.2), 마커 재사용 로직 단순화(§2.2 #111 회귀). 모두 전용 회귀 테스트가 지키고 있으며 과거에 실제로 깨졌다.
+
+---
+
+## 9. "적법한 앵커 후보가 리젝트되는" 지점 전수 조사
+
+anchor가 거부되는 곳은 **생성(process-diff-elements)** 과 **적용(align-anchors)** 두 단계에 흩어져 있다. 각각이 "정당한 거부"인지 "적법한 후보를 잘못 버리는 것"인지 분류한다.
+
+### 9.1 생성 단계 거부
+
+| # | 위치 | 조건 | 판정 |
+|---|---|---|---|
+| C1 | `process-diff-elements.ts:355,419,488` | 앵커 쌍은 **양쪽 첫 토큰이 모두 `LINE_START`**일 때만 생성 | **정당.** 한쪽만 줄 시작이면 두 지점은 서로 다른 줄 위치라 억지 정렬 시 오히려 어긋남. |
+| C2 | `getOrCreateAnchor:55` | 그 자리 `<DS-ANCHOR>`가 이미 이번 run에서 사용 중(`markerElements.has`)이면 `null` | **경계적.** 두 논리 앵커가 같은 DOM 지점을 가리키면 두 번째는 버려짐. 드묾. |
+| C3 | `getAnchorElForLine:290` | `lineBoundaries[lineNumber].startWhich` 없음 → `null` | 정당(측정 불가). |
+| C4 | `getDiffMarkerEl`→`getOrCreateEmptyDiffMarker` | empty-side 마커 자리를 못 잡으면 앵커 없음 | 대개 정당(자리 없음). |
+
+→ 생성 단계의 주 거부(C1)는 **의도적이고 옳다.**
+
+### 9.2 적용 단계 거부 (`align-anchors.ts`)
+
+| # | 위치 | 조건 | 판정 |
+|---|---|---|---|
+| A1 | `:63` 가시성 가드 | `!isConnected || offsetParent===null` | 정당(측정 불가). display:none 앵커의 all-zero gBCR 방지. |
+| A2 | `:79` **단조성 가드** | (수정 전) `leftY < prevLeftY \|\| rightY < prevRightY` — **OR** | **버그. 적법한 후보를 리젝트.** |
+| A3 | `:100` 임계값 | `\|delta - pair.delta\| <= 1` | 정당(no-op). |
+
+### 9.3 핵심 버그: 단조성 가드의 OR 판정 (A2)
+
+`e0e8e38` 커밋이 방어하려던 **실제** 발산 원인은 커밋 메시지에 명시돼 있다:
+
+> *"pair_i is above pair_j on the left but below pair_j on the right … applying padding to pair_i pushes pair_j's opposite side further away … Each iteration roughly multiplies the delta."*
+
+즉 발산은 **한쪽만 역행하는 "교차 역전(cross-side inversion)"** 에서만 일어난다. 그런데 가드는 `leftY < prevLeftY || rightY < prevRightY`(**OR**)로 구현돼, **양쪽이 함께 역행**하는 경우까지 싸잡아 skip했다.
+
+**양쪽이 함께 Y가 위로 돌아가는 것은 표 셀/다단 레이아웃에서 다음 열(column)이 시작될 때 정상적으로 발생하는 좌표 리셋이다.** 예: 한 행의 cell1이 3줄(Y=0,20,40), cell2가 1줄(Y=0). cell2의 앵커는 좌우 모두 Y=0으로 돌아오는데, OR 가드는 이를 `Y=0 < prevY=40`으로 보고 **적법한 표 앵커를 전부 리젝트** → 표에서 좌우가 5px+ 어긋난 채 남는다. (표가 많은 한국 법령 문서에서 두드러짐.)
+
+**수정:** OR → **XOR**. "한쪽만 역행(교차 역전)"일 때만 skip하고, "양쪽 함께 역행(새 열 시작)"은 적법으로 보고 적용하며 baseline을 새 위치로 갱신한다.
+
+```ts
+const leftBack = leftY < prevLeftY;
+const rightBack = rightY < prevRightY;
+if (leftBack !== rightBack) { /* 교차 역전 → skip */ }
+else { prevLeftY = leftY; prevRightY = rightY; /* 적용 */ }
+```
+
+- `e0e8e38`의 두 회귀 테스트(`align-anchors.test.ts` right/left 역전)는 **모두 XOR 케이스**라 그대로 통과 — 발산 방어는 유지된다.
+- 신규 테스트 "[표/다단] 양쪽이 함께 역행 → 적용" 추가로 적법 케이스 잠금.
+- 전체 505 테스트 통과.
+
+> 참고: 대안으로 `AnchorPair.leftContainerIndex/rightContainerIndex`(§6-B의 미사용 필드)를 이용해 컨테이너 경계에서 baseline을 리셋하는 방법도 있으나, XOR 판별이 컨테이너 인덱스에 의존하지 않고 발산 메커니즘과 직접 대응하므로 더 견고하다. 다만 이 수정으로 §6-B의 container 필드는 여전히 미사용으로 남는다.
+
+### 9.4 검증 방법
+
+브라우저 DEV 콘솔에서 §6-G의 `diagnoseResidual` 로그를 본다. 수정 전에는 표 문서에서 `reason: "non-monotonic(skip)"` 이 다수 찍히고, 수정 후에는 그 항목들이 사라지고 residual이 ≤1px로 수렴해야 한다.

--- a/docs/alignanchor-investigation.md
+++ b/docs/alignanchor-investigation.md
@@ -294,4 +294,34 @@ else { prevLeftY = leftY; prevRightY = rightY; /* 적용 */ }
 
 ### 9.4 검증 방법
 
-브라우저 DEV 콘솔에서 §6-G의 `diagnoseResidual` 로그를 본다. 수정 전에는 표 문서에서 `reason: "non-monotonic(skip)"` 이 다수 찍히고, 수정 후에는 그 항목들이 사라지고 residual이 ≤1px로 수렴해야 한다.
+브라우저 DEV 콘솔에서 §6-G의 `diagnoseResidual` 로그를 본다. 수정 전에는 표 문서에서 `reason: "cross-inverted(skip)"` 이 다수 찍히고, 수정 후에는 그 항목들이 사라지고 residual이 ≤1px로 수렴해야 한다.
+
+---
+
+## 10. 양쪽에 padding이 붙는 버그 (both-padding)
+
+### 10.1 불변식
+
+한 `AnchorPair`는 **더 아래에 있는 한쪽에만** 패딩이 붙어야 한다(양쪽에 붙으면 서로 반대로 밀려 절대 정렬되지 않음). `applyDeltaToPair`는 적용 시 항상 반대쪽 패딩을 제거(`clearPadding`)하므로 **적용 경로에서는** 불변식이 유지된다.
+
+### 10.2 원인: stale 장부 + skip 경로
+
+`addAnchorPair`(`process-diff-elements.ts:326`)는 이전 run에서 물려받은 양쪽 패딩을 `prevMarkerElements.get(el).adjust`로 감지해 리셋한다. 그러나 이 `adjust` 장부는 **alignAnchors에서 skip된 pair에 대해 갱신되지 않는다**:
+
+- `getOrCreateAnchor`는 재사용 요소를 `{adjust: 0}`으로 초기화(`:56`).
+- pair가 skip(가시성/교차역전/임계값)되면 `applyDeltaToPair`가 호출되지 않아 `adjust`가 0인 채로 남지만, **요소의 CSS `--ds-adjust`/`ds-padded`는 이전 run 값을 그대로 유지**한다.
+
+따라서 다음 run에서 `addAnchorPair`가 `adjust=0`(stale)을 읽으면, 실제로는 CSS에 양쪽 패딩이 남아있어도 리셋 분기를 건너뛴다. 이후 이 pair가 alignAnchors에서 또 skip되면 **양쪽 패딩이 그대로 화면에 남는다.**
+
+역할 병합 시나리오: 요소 L이 run_k에서 pairA의 패딩 대상, 요소 R이 pairB의 패딩 대상이었다가(각각 한쪽), 두 pair가 이후 run에서 skip되어 장부가 stale해지고, diff 변화로 L·R이 **하나의 pair로 병합**되면 → 양쪽 패딩.
+
+### 10.3 수정 (두 지점, ground truth = 실제 CSS)
+
+1. **`alignAnchors` (권위 지점, `align-anchors.ts`):** 각 pair 측정 직전, `leftEl`·`rightEl`이 **둘 다 `ds-padded`**면 `clearPadding`으로 둘 다 제거하고 `pair.delta=0`으로 리셋 → 이어지는 로직이 실제 위치 기준으로 한쪽에만 재적용. 이로써 **어떤 경로로 both-padding이 유입되든 alignAnchors 한 패스 뒤에는 불변식이 회복**된다.
+2. **`addAnchorPair` (발생 원점, `process-diff-elements.ts`):** stale할 수 있는 `adjust` 대신 실제 `ds-padded` 클래스로 both-padding을 재확인해 원점에서 제거.
+
+- `clearPadding()` 헬퍼로 클래스/CSS 변수/장부(`adjust`) 정리를 일원화, `applyDeltaToPair`도 이를 재사용.
+- 신규 테스트 2개(`align-anchors.test.ts` "양쪽 패딩 방어"): both-padded → 위치대로 한쪽 재적용 / both-padded + 정렬됨 → 둘 다 제거.
+- 전체 507 테스트 통과.
+
+> 근본적으로는 skip 경로에서 `markerElements.adjust`를 실제 상태와 동기화하지 않는 **장부-CSS 불일치**가 원인이다. 위 수정은 CSS를 ground truth로 삼아 불일치의 영향을 무력화한다. 장부 자체를 항상 정합하게 유지하는 리팩터링(§6-B의 필드 정리와 함께)은 후속 과제로 남긴다.


### PR DESCRIPTION
## Summary

This PR addresses three interconnected bugs in the sync mode (F2) anchor alignment pipeline that cause misalignment in tables and multi-column layouts, and fixes a DOM mutation observer issue that corrupts newly inserted anchors.

## Key Changes

### 1. Both-padding defense (`align-anchors.ts`, `process-diff-elements.ts`)
- Added guard to detect and normalize impossible state where both left and right elements have `ds-padded` class simultaneously
- This occurs when a pair is skipped during alignment but inherits padding from different previous pairs
- Before measuring, if both sides are padded, clear both and reset `delta=0` to allow fresh calculation
- Prevents pairs from being locked in misaligned state across multiple alignment passes

### 2. XOR monotonicity guard (`align-anchors.ts`)
- **Fixed critical bug in non-monotonicity check** (introduced in `e0e8e38`)
- Changed from OR (`leftY < prevLeftY || rightY < prevRightY`) to XOR logic
- **Root cause**: The OR guard was rejecting legitimate table/multi-column anchors where both sides reset Y coordinates together (new column start), not just pathological cross-side inversions
- XOR correctly identifies only "cross-side inversion" (one side goes back, other goes forward) which causes actual divergence
- "Both sides go back together" is a normal coordinate reset in tables → now allowed and baseline is updated
- Fixes widespread misalignment in Korean law documents with heavy table usage
- All existing regression tests pass; added new test for coordinated Y reset case

### 3. Anchor index corruption fix (`editor.ts`, new test file)
- **Root cause**: MutationObserver callback was deleting `data-anchor-index` from newly inserted `<DS-ANCHOR>` and `<DS-DIFF>` elements
- Timeline: `getOrCreateAnchor` inserts element → `activateAnchorEl` synchronously sets index → MutationObserver callback (next microtask) sees added node with index and deletes it
- Result: New anchors lose `[data-anchor-index]` selector match → `display:none` in sync mode → visibility guard skips them → alignment fails on first appearance
- **Fix**: Extract cleanup logic to `cleanCopiedAnchorAttrs()` function that explicitly excludes `ANCHOR_TAG_NAME` and `DIFF_TAG_NAME` elements
- These are engine-managed and never copied by browser; only clean up content blocks (p/div/td) that were duplicated during line breaks
- Added comprehensive test suite (`editor-mutation-cleanup.test.ts`) covering all cases

### 4. Diagnostic tooling (`align-anchors.ts`)
- Added `diagnoseResidual()` function (DEV builds only) that re-measures all pairs after alignment pass
- Reports any residual misalignment >1px with reason classification: `unmeasurable(skip)`, `cross-inverted(skip)`, or `processed-but-off`
- Helps distinguish between skipped pairs vs. pairs that were processed but still misaligned
- Logged to console.table for easy inspection in browser DevTools

### 5. Code cleanup
- Extracted `clearPadding()` helper to centralize padding state cleanup (classes + CSS variables + marker element map)
- Reused in both `applyDeltaToPair` and new both-padding defense
- Improved comments explaining the invariants and failure modes

## Testing

- **Regression tests**: All existing 505 tests pass
- **New tests**: 
  - 2 both-padding defense cases (`align-anchors.test.ts`)
  - 1 coordinated Y-reset case for tables/multi-column (`align-anchors.test.ts`)
  - 6 mutation cleanup cases (`editor-mutation-cleanup.test.ts`)
- Total: 513 tests passing

## Impact

- **Tables**: Fixes widespread misalignment in documents with table layouts (especially Korean law documents)
- **Multi-column layouts**: Correctly handles coordinate resets when moving between columns
- **Sync mode stability**: Prevents stale padding state from persisting across alignment passes
- **New anchor insertion**: Ensures newly created

https://claude.ai/code/session_01EFoVCvcoCw6StA2vBtL5eh