### PR TITLE
fix(engine): 옵션 변경 diff run을 스케줄러 경유로 직렬화 (#121)

### DIFF
--- a/core/src/engine/diffseek-engine.ts
+++ b/core/src/engine/diffseek-engine.ts
@@ -159,7 +159,7 @@ export class DiffseekEngine {
 
 			if (runWorkflow) {
 				this.cancelOngoingOperations();
-				this.startDiffWorkflow();
+				this.requestDiffWorkflowRun();
 			}
 		}
 


### PR DESCRIPTION
## 요약

이슈 #121 수정. `updateDiffOptions()`가 diff 옵션 변경 시 스케줄러를 우회해 `startDiffWorkflow()`를 직접 호출하던 것을 `requestDiffWorkflowRun()`으로 변경해 스케줄러 경유로 직렬화한다.

## 문제

직접 호출 경로에서, 앞선 `cancelOngoingOperations()`가 `diffAbortController`를 `null`로 만들어 `startDiffWorkflow`의 abort+yield 안전장치(715-719)를 스킵한다. 이때 진행 중이던 run이 `prevMarkerElements`를 정리(`endMarkerUpdate`)하기 전에 새 run이 동기적으로 721행 assertion을 발화한다:

```
throw new Error("DiffseekEngine: previous diff elements have not been cleaned up.");
```

이 throw는 바깥 try/catch 밖이고 직접 호출부가 await/catch를 하지 않으므로 **unhandled promise rejection** + 해당 옵션 변경 회차의 diff 유실로 이어진다. (큰 문서에서 processing 단계가 50ms yield 창을 넘길 때만 재현)

## 수정

`requestDiffWorkflowRun()`으로 스케줄러를 경유시키면 `WorkflowScheduler._drain`의 while 루프가 run을 직렬화한다. 이전 run의 `_execute` promise가 완전히 unwind(내부 finally의 `endMarkerUpdate`로 `prevMarkerElements` 정리)된 뒤에만 다음 run이 시작되므로 인터리브와 안전장치 스킵이 원천 소멸한다. `handleEditorContentChanging()`의 기존 패턴(`cancelOngoingOperations()` → `requestDiffWorkflowRun()`)과도 일치.

## 테스트

`npm run test` — 513개 전부 통과.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)