### PR TITLE
ci(release): workflow_dispatch로 수동 릴리즈 트리거 지원

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to create (e.g. v2.1.3)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -26,8 +32,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: DiffSeek ${{ github.ref_name }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: DiffSeek ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: |
             artifacts/diffseek.html


### PR DESCRIPTION
## 배경

`v2.1.3`(patch) 릴리즈를 태그해서 트리거하려 했으나, 웹 실행 환경의 git 프록시가 **태그 push를 403으로 차단**하고 GitHub MCP에도 tag/ref/release 생성 도구가 없어 이 환경 안에서 릴리즈를 직접 킥할 방법이 없었습니다. 기존 `release.yml`은 `push: tags: v*` 트리거만 있어 수동 실행도 불가했습니다.

## 변경

`release.yml`에 `workflow_dispatch` 경로를 추가했습니다.

- `tag` 입력(required)을 받아 GitHub Actions 화면/API에서 릴리즈를 직접 킥 가능
- `tag_name` / `name` 은 `inputs.tag`가 있으면 우선 사용, 없으면 기존 `github.ref_name`으로 폴백 → **기존 태그 push 트리거와 완전 호환**
- `softprops/action-gh-release`가 존재하지 않는 태그를 실행 커밋(SHA) 기준으로 생성하므로, main HEAD에 대해 dispatch하면 태그가 새로 만들어짐

## 릴리즈 방법 (머지 후)

1. 이 PR을 `main`에 머지
2. Actions → **Create Release** → **Run workflow** → branch `main`, tag `v2.1.3` 입력 → 실행
   (또는 `gh workflow run release.yml -f tag=v2.1.3 --ref main`)

빌드(`npm run pack`) → `v2.1.3` 태그 생성 + 릴리즈 노트 자동 생성 + 아티팩트 첨부까지 워크플로가 처리합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqGMPcH69Vi89obMBarQR4)_